### PR TITLE
feat: replace FragilityModel-Component FK with many-to-many bridge table

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,12 @@ A project maintainer will review your PR. They will check the "JSON Diff" to see
 **For Developers:** If you need to change the database schema (e.g., adding a new field like `data_source_type`, renaming a column, or creating a new table), you must follow a strict "Round-Trip" protocol. This ensures that the mapping between our JSON source of truth and the runtime database remains perfectly synced.
 
 #### Step 1: Prepare Your Workspace
-Start with a fresh local database state:
+Start with a fresh local database populated with the current canonical data. **Keep a copy of this database** — you will need it later to apply your new migrations.
 ```bash
+rm -f db.sqlite3
 python manage.py migrate
 python manage.py ingest
+cp db.sqlite3 db_before_changes.sqlite3
 ```
 
 #### Step 2: Implement Schema Change & Data Migration
@@ -160,41 +162,45 @@ Modify `models.py` and create your migrations.
 *   *Example:* Use `RunPython` operations or default values in the migration to ensure all 2000+ existing rows remain valid.
 ```bash
 python manage.py makemigrations
-python manage.py migrate
 ```
 
 #### Step 3: Update the Pipelines
-You must update the two commands that bridge the gap between JSON and DB:
+Update the remaining code to match the **new** schema:
+*   **`serializer.py`:** Update serializer fields and classes to reflect the new model structure.
 *   **`ingest` command:** Update the logic to map JSON keys to your new DB fields.
 *   **`export_data` command:** Update the logic to serialize your new DB fields back to JSON.
+*   **`admin.py`:** Register any new models and update existing admin classes as needed.
 *   *Constraint:* The loop `Export(Ingest(Source))` must be idempotent (lossless).
 
-#### Step 4: Verification ( The "Round-Trip" Protocol)
-Run these commands in order to prove that data can flow safely in both directions:
-
-**1. Capture the new DB state:**
+#### Step 4: Apply Migrations to the Saved Database
+Restore the database you saved in Step 1 and apply your new migrations to it. This transforms the data **through the migration**, ensuring correctness without relying on the updated serializers (which expect the new schema).
 ```bash
+cp db_before_changes.sqlite3 db.sqlite3
+python manage.py migrate
+```
+
+#### Step 5: Export Updated Canonical Data
+Export the migrated database to generate the updated canonical JSON files and fixture:
+```bash
+python manage.py export_data --output_dir resources/data/
 python manage.py dumpdata ned_app --indent 2 > ned_app/fixtures/initial_data.json
 ```
 
-**2. Test Export (DB -> JSON):**
+#### Step 6: Verification (The "Round-Trip" Protocol)
+Run these tests to prove that data flows safely in both directions:
 ```bash
 python manage.py test ned_app.tests.test_data_integrity.DataIntegrityTests.test_db_round_trip
-```
-
-**3. Update Source Files (Propagate changes to JSON):**
-This is the moment your schema change actually updates the canonical data files.
-```bash
-python manage.py export_data
-```
-
-**4. Test Ingest (JSON -> DB):**
-```bash
 python manage.py test ned_app.tests.test_data_integrity.DataIntegrityTests.test_json_to_db_to_json_round_trip_is_lossless
 ```
 
-#### Step 5: Finalize and Commit
-Update `README.md` and templates in `resources/example_data/` if your change affects the user-facing data structure. Then, commit all changed files (models, migrations, updated JSONs, scripts, and fixtures) and open your PR.
+#### Step 7: Update and Run Unit Tests
+Review and update existing unit tests to match the new schema, and add tests for any new models, serializers, or commands. Ensure the full test suite passes:
+```bash
+python manage.py test ned_app.tests
+```
+
+#### Step 8: Finalize and Commit
+Update `README.md` and templates in `resources/example_data/` if your change affects the user-facing data structure. Commit all changed files (models, migrations, updated JSONs, scripts, and fixtures) and open your PR.
 
 ### Launch the Django Admin
 To launch and take advantage of the administrative interface, run the web server:

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ A project maintainer will review your PR. They will check the "JSON Diff" to see
 #### Step 1: Prepare Your Workspace
 Start with a fresh local database populated with the current canonical data. **Keep a copy of this database** — you will need it later to apply your new migrations.
 ```bash
+cp db.sqlite3 db_before_changes.sqlite3
 rm -f db.sqlite3
 python manage.py migrate
 python manage.py ingest
-cp db.sqlite3 db_before_changes.sqlite3
 ```
 
 #### Step 2: Implement Schema Change & Data Migration

--- a/ned_app/admin.py
+++ b/ned_app/admin.py
@@ -9,6 +9,7 @@ from ned_app.models import (
     FragilityCurve,
     FragilityModel,
     ExperimentFragilityModelBridge,
+    ComponentFragilityModelBridge,
 )
 
 
@@ -47,10 +48,16 @@ class FragilityCurveAdmin(admin.ModelAdmin):
 @admin.register(FragilityModel)
 class FragilityModelAdmin(admin.ModelAdmin):
     # how column data is displayed in the report for all entered data
-    list_display = ('id', 'component')
+    list_display = ('id',)
 
 
 @admin.register(ExperimentFragilityModelBridge)
 class ExperimentFragilityModelBridgeAdmin(admin.ModelAdmin):
     # how column data is displayed in the report for all entered data
     list_display = ('experiment', 'fragility_model')
+
+
+@admin.register(ComponentFragilityModelBridge)
+class ComponentFragilityModelBridgeAdmin(admin.ModelAdmin):
+    # how column data is displayed in the report for all entered data
+    list_display = ('component', 'fragility_model')

--- a/ned_app/management/commands/export_data.py
+++ b/ned_app/management/commands/export_data.py
@@ -228,9 +228,7 @@ class Command(BaseCommand):
             }
             data.append(bridge_data)
 
-        file_path = os.path.join(
-            output_dir, 'component_fragility_model_bridge.json'
-        )
+        file_path = os.path.join(output_dir, 'component_fragility_model_bridge.json')
         with open(file_path, 'w') as f:
             json.dump(data, f, indent=4, sort_keys=True, cls=DecimalEncoder)
 

--- a/ned_app/management/commands/export_data.py
+++ b/ned_app/management/commands/export_data.py
@@ -8,6 +8,7 @@ from ned_app.models import (
     Experiment,
     FragilityModel,
     ExperimentFragilityModelBridge,
+    ComponentFragilityModelBridge,
     FragilityCurve,
 )
 
@@ -76,6 +77,7 @@ class Command(BaseCommand):
         self.export_component_data(output_dir)
         self.export_experiment_data(output_dir)
         self.export_fragility_model_data(output_dir)
+        self.export_component_fragility_bridge_data(output_dir)
         self.export_experiment_fragility_bridge_data(output_dir)
         self.export_fragility_curve_data(output_dir)
 
@@ -197,7 +199,6 @@ class Command(BaseCommand):
             fm_data = {
                 'id': fm.id,
                 'p58_fragility': fm.p58_fragility,
-                'component': fm.component.component_id,
                 'comp_detail': fm.comp_detail,
                 'material': fm.material,
                 'size_class': fm.size_class,
@@ -206,6 +207,30 @@ class Command(BaseCommand):
             data.append(fm_data)
 
         file_path = os.path.join(output_dir, 'fragility_model.json')
+        with open(file_path, 'w') as f:
+            json.dump(data, f, indent=4, sort_keys=True, cls=DecimalEncoder)
+
+    def export_component_fragility_bridge_data(self, output_dir):
+        """
+        Export ComponentFragilityModelBridge model data to JSON file.
+
+        Args:
+            output_dir (str): Directory where the JSON file will be saved.
+        """
+        self.stdout.write('Exporting ComponentFragilityModelBridge data...')
+        bridges = ComponentFragilityModelBridge.objects.all()
+
+        data = []
+        for bridge in bridges:
+            bridge_data = {
+                'component': bridge.component.component_id,
+                'fragility_model': bridge.fragility_model_id,
+            }
+            data.append(bridge_data)
+
+        file_path = os.path.join(
+            output_dir, 'component_fragility_model_bridge.json'
+        )
         with open(file_path, 'w') as f:
             json.dump(data, f, indent=4, sort_keys=True, cls=DecimalEncoder)
 

--- a/ned_app/management/commands/ingest.py
+++ b/ned_app/management/commands/ingest.py
@@ -8,6 +8,7 @@ from ned_app.models import (
     FragilityModel,
     Experiment,
     ExperimentFragilityModelBridge,
+    ComponentFragilityModelBridge,
     FragilityCurve,
 )
 from ned_app.serialization.file_and_path_utiles import build_json_data_file_path
@@ -17,6 +18,7 @@ from ned_app.serialization.serializer import (
     FragilityModelSerializer,
     ExperimentSerializer,
     ExperimentFragilityModelBridgeSerializer,
+    ComponentFragilityModelBridgeSerializer,
     FragilityCurveSerializer,
 )
 
@@ -60,6 +62,12 @@ class Command(BaseCommand):
                 'serializer': FragilityModelSerializer,
                 'file': 'fragility_model.json',
                 'lookup_field': ['id'],
+            },
+            {
+                'model': ComponentFragilityModelBridge,
+                'serializer': ComponentFragilityModelBridgeSerializer,
+                'file': 'component_fragility_model_bridge.json',
+                'lookup_field': ['component', 'fragility_model'],
             },
             {
                 'model': Experiment,

--- a/ned_app/migrations/0015_componentfragilitymodelbridge.py
+++ b/ned_app/migrations/0015_componentfragilitymodelbridge.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('ned_app', '0014_alter_component_component_id_alter_component_id_and_more'),
     ]

--- a/ned_app/migrations/0015_componentfragilitymodelbridge.py
+++ b/ned_app/migrations/0015_componentfragilitymodelbridge.py
@@ -1,0 +1,49 @@
+"""Create ComponentFragilityModelBridge table."""
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ned_app', '0014_alter_component_component_id_alter_component_id_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ComponentFragilityModelBridge',
+            fields=[
+                (
+                    'id',
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name='ID',
+                    ),
+                ),
+                (
+                    'component',
+                    models.ForeignKey(
+                        help_text='Component ID (component_id)',
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to='ned_app.component',
+                        to_field='component_id',
+                    ),
+                ),
+                (
+                    'fragility_model',
+                    models.ForeignKey(
+                        help_text='Fragility model ID',
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to='ned_app.fragilitymodel',
+                    ),
+                ),
+            ],
+            options={
+                'verbose_name': 'Component - Fragility Pair',
+                'verbose_name_plural': 'Component - Fragility Pairs',
+            },
+        ),
+    ]

--- a/ned_app/migrations/0016_populate_component_fragility_bridge.py
+++ b/ned_app/migrations/0016_populate_component_fragility_bridge.py
@@ -1,0 +1,54 @@
+"""Populate ComponentFragilityModelBridge from FragilityModel.component FK."""
+
+from django.db import migrations
+
+
+def populate_bridge(apps, schema_editor):
+    """Copy component FK from FragilityModel into bridge table and verify."""
+    FragilityModel = apps.get_model('ned_app', 'FragilityModel')
+    ComponentFragilityModelBridge = apps.get_model(
+        'ned_app', 'ComponentFragilityModelBridge'
+    )
+
+    fragility_models = FragilityModel.objects.all()
+    fm_count = fragility_models.count()
+
+    for fm in fragility_models:
+        ComponentFragilityModelBridge.objects.create(
+            component=fm.component,
+            fragility_model=fm,
+        )
+
+    # Verify: bridge count matches FragilityModel count
+    bridge_count = ComponentFragilityModelBridge.objects.count()
+    if bridge_count != fm_count:
+        raise ValueError(
+            f'Bridge count ({bridge_count}) does not match '
+            f'FragilityModel count ({fm_count}).'
+        )
+
+    # Verify: every bridge row's component matches the original FM's component
+    for fm in fragility_models:
+        bridge = ComponentFragilityModelBridge.objects.get(fragility_model=fm)
+        if bridge.component_id != fm.component_id:
+            raise ValueError(
+                f'Bridge component mismatch for FragilityModel {fm.id}: '
+                f'bridge has {bridge.component_id}, '
+                f'FM has {fm.component_id}.'
+            )
+
+
+def reverse_bridge(apps, schema_editor):
+    """No reverse needed; the bridge table will be dropped by reversing 0015."""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ned_app', '0015_componentfragilitymodelbridge'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_bridge, reverse_bridge),
+    ]

--- a/ned_app/migrations/0016_populate_component_fragility_bridge.py
+++ b/ned_app/migrations/0016_populate_component_fragility_bridge.py
@@ -44,7 +44,6 @@ def reverse_bridge(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('ned_app', '0015_componentfragilitymodelbridge'),
     ]

--- a/ned_app/migrations/0017_remove_fragilitymodel_component.py
+++ b/ned_app/migrations/0017_remove_fragilitymodel_component.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ('ned_app', '0016_populate_component_fragility_bridge'),
     ]

--- a/ned_app/migrations/0017_remove_fragilitymodel_component.py
+++ b/ned_app/migrations/0017_remove_fragilitymodel_component.py
@@ -1,0 +1,17 @@
+"""Remove component FK from FragilityModel."""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ned_app', '0016_populate_component_fragility_bridge'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='fragilitymodel',
+            name='component',
+        ),
+    ]

--- a/ned_app/models.py
+++ b/ned_app/models.py
@@ -450,7 +450,6 @@ class FragilityModel(models.Model):
 
     Attributes:
         p58_fragility (str): P-58 fragility id associated with this fragility model, if applicable.
-        component (id): Identifier of the component type.
         comp_detail (str): Classification or short description of the component attachment detailing.
         material (str): Classification or short description of the component material (if applicable).
         size_class (str): Classification or short description of the general size of this particular components compared to others of the same type (if applicable).
@@ -463,12 +462,6 @@ class FragilityModel(models.Model):
         max_length=50,
         blank=True,
         help_text='P-58 fragility id associated with this fragility model, if applicable.',
-    )
-    component = models.ForeignKey(
-        'Component',
-        on_delete=models.PROTECT,
-        to_field='component_id',
-        help_text='Identifier of the component type.',
     )
     comp_detail = models.CharField(
         _('component detail tag'),
@@ -524,6 +517,35 @@ class ExperimentFragilityModelBridge(models.Model):
 
     def __str__(self):
         return f'{self.experiment}_{self.fragility_model}'
+
+
+class ComponentFragilityModelBridge(models.Model):
+    """
+    A bridge model facilitating a many-to-many relationship between components and fragility models.
+
+    Attributes:
+        component (str): Component ID (component_id).
+        fragility_model (str): Fragility model ID.
+    """
+
+    component = models.ForeignKey(
+        'Component',
+        on_delete=models.PROTECT,
+        to_field='component_id',
+        help_text='Component ID (component_id)',
+    )
+    fragility_model = models.ForeignKey(
+        'FragilityModel',
+        on_delete=models.PROTECT,
+        help_text='Fragility model ID',
+    )
+
+    class Meta:
+        verbose_name = 'Component - Fragility Pair'
+        verbose_name_plural = 'Component - Fragility Pairs'
+
+    def __str__(self):
+        return f'{self.component}_{self.fragility_model}'
 
 
 class FragilityCurve(models.Model):

--- a/ned_app/serialization/serializer.py
+++ b/ned_app/serialization/serializer.py
@@ -9,6 +9,7 @@ from ned_app.models import (
     FragilityModel,
     Experiment,
     ExperimentFragilityModelBridge,
+    ComponentFragilityModelBridge,
     FragilityCurve,
 )
 from ned_app.validators import validate_nistir_component_id
@@ -136,21 +137,16 @@ class ComponentSerializer(serializers.ModelSerializer):
 
 class FragilityModelSerializer(serializers.ModelSerializer):
     """
-    Serializer for FragilityModel with component relationship.
+    Serializer for FragilityModel.
 
-    Uses component_id as the slug field for component lookups.
+    The component relationship is now managed through ComponentFragilityModelBridge.
     """
-
-    component = serializers.SlugRelatedField(
-        slug_field='component_id', queryset=Component.objects.all()
-    )
 
     class Meta:
         model = FragilityModel
         fields = [
             'id',
             'p58_fragility',
-            'component',
             'comp_detail',
             'material',
             'size_class',
@@ -225,6 +221,29 @@ class ExperimentFragilityModelBridgeSerializer(serializers.ModelSerializer):
         fields = [
             'id',
             'experiment',
+            'fragility_model',
+        ]
+
+
+class ComponentFragilityModelBridgeSerializer(serializers.ModelSerializer):
+    """
+    Serializer for ComponentFragilityModelBridge relationship.
+
+    Manages the many-to-many relationship between components and fragility models.
+    """
+
+    component = serializers.SlugRelatedField(
+        slug_field='component_id', queryset=Component.objects.all()
+    )
+    fragility_model = serializers.SlugRelatedField(
+        slug_field='id', queryset=FragilityModel.objects.all()
+    )
+
+    class Meta:
+        model = ComponentFragilityModelBridge
+        fields = [
+            'id',
+            'component',
             'fragility_model',
         ]
 

--- a/ned_app/tests/management/test_export_data_command.py
+++ b/ned_app/tests/management/test_export_data_command.py
@@ -10,6 +10,7 @@ from ned_app.models import (
     Experiment,
     FragilityModel,
     ExperimentFragilityModelBridge,
+    ComponentFragilityModelBridge,
     FragilityCurve,
 )
 
@@ -76,12 +77,18 @@ class ExportDataCommandTest(TestCase):
 
         self.fragility_model = FragilityModel.objects.create(
             id='test-fm-001',
-            component=self.component,
             p58_fragility='B2011.001',
             comp_detail='Steel connection',
             material='Cold-formed steel',
             size_class='Medium',
             comp_description='Test fragility model description',
+        )
+
+        self.component_fragility_bridge = (
+            ComponentFragilityModelBridge.objects.create(
+                component=self.component,
+                fragility_model=self.fragility_model,
+            )
         )
 
         self.bridge = ExperimentFragilityModelBridge.objects.create(
@@ -113,6 +120,7 @@ class ExportDataCommandTest(TestCase):
             'component.json',
             'experiment.json',
             'fragility_model.json',
+            'component_fragility_model_bridge.json',
             'experiment_fragility_model_bridge.json',
             'fragility_curve.json',
         ]
@@ -260,8 +268,7 @@ class ExportDataCommandTest(TestCase):
 
             self.assertIn('id', fm_data)
             self.assertEqual(fm_data['id'], 'test-fm-001')
-            self.assertIn('component', fm_data)
-            self.assertEqual(fm_data['component'], 'B.20.1.1.A')
+            self.assertNotIn('component', fm_data)
 
             self.assertIn('p58_fragility', fm_data)
             self.assertEqual(fm_data['p58_fragility'], 'B2011.001')
@@ -274,6 +281,27 @@ class ExportDataCommandTest(TestCase):
             self.assertIn('comp_description', fm_data)
             self.assertEqual(
                 fm_data['comp_description'], 'Test fragility model description'
+            )
+
+        with open(
+            os.path.join(
+                self.temp_dir, 'component_fragility_model_bridge.json'
+            ),
+            'r',
+        ) as f:
+            cfm_bridge_data = json.load(f)
+            self.assertEqual(len(cfm_bridge_data), 1)
+            cfm_bridge = cfm_bridge_data[0]
+
+            self.assertIn('component', cfm_bridge)
+            self.assertEqual(cfm_bridge['component'], 'B.20.1.1.A')
+            self.assertIn('fragility_model', cfm_bridge)
+            self.assertEqual(cfm_bridge['fragility_model'], 'test-fm-001')
+
+            self.assertEqual(
+                len(cfm_bridge.keys()),
+                2,
+                'ComponentFragilityModelBridge should only have 2 fields',
             )
 
         with open(
@@ -333,6 +361,7 @@ class ExportDataCommandTest(TestCase):
         """Clean up test data and temporary files."""
         FragilityCurve.objects.all().delete()
         ExperimentFragilityModelBridge.objects.all().delete()
+        ComponentFragilityModelBridge.objects.all().delete()
         FragilityModel.objects.all().delete()
         Experiment.objects.all().delete()
         Reference.objects.all().delete()

--- a/ned_app/tests/management/test_export_data_command.py
+++ b/ned_app/tests/management/test_export_data_command.py
@@ -284,9 +284,7 @@ class ExportDataCommandTest(TestCase):
             )
 
         with open(
-            os.path.join(
-                self.temp_dir, 'component_fragility_model_bridge.json'
-            ),
+            os.path.join(self.temp_dir, 'component_fragility_model_bridge.json'),
             'r',
         ) as f:
             cfm_bridge_data = json.load(f)

--- a/ned_app/tests/management/test_ingest_command.py
+++ b/ned_app/tests/management/test_ingest_command.py
@@ -16,6 +16,7 @@ from ned_app.models import (
     Experiment,
     FragilityModel,
     ExperimentFragilityModelBridge,
+    ComponentFragilityModelBridge,
     FragilityCurve,
 )
 
@@ -72,7 +73,6 @@ class IngestCommandTests(TransactionTestCase):
             fragility_model_data = [
                 {
                     'id': 'fm-001',
-                    'component': 'B.20.1.1.A',
                     'p58_fragility': 'B2011.001',
                     'comp_detail': 'Standard attachment',
                     'material': 'Steel',
@@ -80,11 +80,21 @@ class IngestCommandTests(TransactionTestCase):
                 },
                 {
                     'id': 'fm-002',
-                    'component': 'D.30.3.2.B',
                     'p58_fragility': '',
                     'comp_detail': 'Anchored',
                     'material': 'Steel tank',
                     'comp_description': 'Residential water heater',
+                },
+            ]
+
+            component_fragility_bridge_data = [
+                {
+                    'component': 'B.20.1.1.A',
+                    'fragility_model': 'fm-001',
+                },
+                {
+                    'component': 'D.30.3.2.B',
+                    'fragility_model': 'fm-002',
                 },
             ]
 
@@ -180,6 +190,7 @@ class IngestCommandTests(TransactionTestCase):
                 'reference.json': reference_data,
                 'component.json': component_data,
                 'fragility_model.json': fragility_model_data,
+                'component_fragility_model_bridge.json': component_fragility_bridge_data,
                 'experiment.json': experiment_data,
                 'experiment_fragility_model_bridge.json': bridge_data,
                 'fragility_curve.json': fragility_curve_data,
@@ -202,6 +213,7 @@ class IngestCommandTests(TransactionTestCase):
             self.assertEqual(Reference.objects.count(), 2)
             self.assertEqual(Component.objects.count(), 2)
             self.assertEqual(FragilityModel.objects.count(), 2)
+            self.assertEqual(ComponentFragilityModelBridge.objects.count(), 2)
             self.assertEqual(Experiment.objects.count(), 2)
             self.assertEqual(ExperimentFragilityModelBridge.objects.count(), 2)
             self.assertEqual(FragilityCurve.objects.count(), 3)
@@ -214,11 +226,23 @@ class IngestCommandTests(TransactionTestCase):
             self.assertEqual(exp_002.reference.id, 'ref-001')
             self.assertEqual(exp_002.component.component_id, 'D.30.3.2.B')
 
-            fm_001 = FragilityModel.objects.get(id='fm-001')
-            self.assertEqual(fm_001.component.component_id, 'B.20.1.1.A')
+            cfm_bridge_1 = ComponentFragilityModelBridge.objects.get(
+                component__component_id='B.20.1.1.A',
+                fragility_model__id='fm-001',
+            )
+            self.assertEqual(
+                cfm_bridge_1.component.component_id, 'B.20.1.1.A'
+            )
+            self.assertEqual(cfm_bridge_1.fragility_model.id, 'fm-001')
 
-            fm_002 = FragilityModel.objects.get(id='fm-002')
-            self.assertEqual(fm_002.component.component_id, 'D.30.3.2.B')
+            cfm_bridge_2 = ComponentFragilityModelBridge.objects.get(
+                component__component_id='D.30.3.2.B',
+                fragility_model__id='fm-002',
+            )
+            self.assertEqual(
+                cfm_bridge_2.component.component_id, 'D.30.3.2.B'
+            )
+            self.assertEqual(cfm_bridge_2.fragility_model.id, 'fm-002')
 
             bridge_1 = ExperimentFragilityModelBridge.objects.get(
                 experiment__id='exp-001', fragility_model__id='fm-001'
@@ -539,8 +563,14 @@ class IngestCommandTests(TransactionTestCase):
             fragility_model_data = [
                 {
                     'id': 'fm-idem',
-                    'component': 'A.10.1.1',
                     'comp_description': 'Original FM Description',
+                }
+            ]
+
+            component_fragility_bridge_data = [
+                {
+                    'component': 'A.10.1.1',
+                    'fragility_model': 'fm-idem',
                 }
             ]
 
@@ -578,6 +608,7 @@ class IngestCommandTests(TransactionTestCase):
                 'reference.json': reference_data,
                 'component.json': component_data,
                 'fragility_model.json': fragility_model_data,
+                'component_fragility_model_bridge.json': component_fragility_bridge_data,
                 'experiment.json': experiment_data,
                 'experiment_fragility_model_bridge.json': bridge_data,
                 'fragility_curve.json': fragility_curve_data,
@@ -601,6 +632,7 @@ class IngestCommandTests(TransactionTestCase):
                 self.assertEqual(Reference.objects.count(), 1)
                 self.assertEqual(Component.objects.count(), 1)
                 self.assertEqual(FragilityModel.objects.count(), 1)
+                self.assertEqual(ComponentFragilityModelBridge.objects.count(), 1)
                 self.assertEqual(Experiment.objects.count(), 1)
                 self.assertEqual(ExperimentFragilityModelBridge.objects.count(), 1)
                 self.assertEqual(FragilityCurve.objects.count(), 1)
@@ -631,6 +663,7 @@ class IngestCommandTests(TransactionTestCase):
                 self.assertEqual(Reference.objects.count(), 1)
                 self.assertEqual(Component.objects.count(), 1)
                 self.assertEqual(FragilityModel.objects.count(), 1)
+                self.assertEqual(ComponentFragilityModelBridge.objects.count(), 1)
                 self.assertEqual(Experiment.objects.count(), 1)
                 self.assertEqual(ExperimentFragilityModelBridge.objects.count(), 1)
                 self.assertEqual(FragilityCurve.objects.count(), 1)
@@ -655,6 +688,7 @@ class IngestCommandTests(TransactionTestCase):
                 self.assertEqual(Reference.objects.count(), 1)
                 self.assertEqual(Component.objects.count(), 1)
                 self.assertEqual(FragilityModel.objects.count(), 1)
+                self.assertEqual(ComponentFragilityModelBridge.objects.count(), 1)
                 self.assertEqual(Experiment.objects.count(), 1)
                 self.assertEqual(ExperimentFragilityModelBridge.objects.count(), 1)
                 self.assertEqual(FragilityCurve.objects.count(), 1)

--- a/ned_app/tests/management/test_ingest_command.py
+++ b/ned_app/tests/management/test_ingest_command.py
@@ -230,18 +230,14 @@ class IngestCommandTests(TransactionTestCase):
                 component__component_id='B.20.1.1.A',
                 fragility_model__id='fm-001',
             )
-            self.assertEqual(
-                cfm_bridge_1.component.component_id, 'B.20.1.1.A'
-            )
+            self.assertEqual(cfm_bridge_1.component.component_id, 'B.20.1.1.A')
             self.assertEqual(cfm_bridge_1.fragility_model.id, 'fm-001')
 
             cfm_bridge_2 = ComponentFragilityModelBridge.objects.get(
                 component__component_id='D.30.3.2.B',
                 fragility_model__id='fm-002',
             )
-            self.assertEqual(
-                cfm_bridge_2.component.component_id, 'D.30.3.2.B'
-            )
+            self.assertEqual(cfm_bridge_2.component.component_id, 'D.30.3.2.B')
             self.assertEqual(cfm_bridge_2.fragility_model.id, 'fm-002')
 
             bridge_1 = ExperimentFragilityModelBridge.objects.get(

--- a/ned_app/tests/serialization/test_serializers.py
+++ b/ned_app/tests/serialization/test_serializers.py
@@ -10,6 +10,7 @@ from ned_app.serialization.serializer import (
     FragilityModelSerializer,
     ExperimentSerializer,
     ExperimentFragilityModelBridgeSerializer,
+    ComponentFragilityModelBridgeSerializer,
     FragilityCurveSerializer,
 )
 from ned_app.models import (
@@ -18,6 +19,7 @@ from ned_app.models import (
     FragilityModel,
     Experiment,
     ExperimentFragilityModelBridge,
+    ComponentFragilityModelBridge,
     FragilityCurve,
 )
 
@@ -417,20 +419,12 @@ class ComponentSerializerTest(TestCase):
 
 
 class FragilityModelSerializerTest(TestCase):
-    """Test cases for the FragilityModelSerializer, focusing on foreign key validation."""
+    """Test cases for the FragilityModelSerializer."""
 
-    def setUp(self):
-        """Set up test data."""
-        self.component = Component.objects.create(
-            component_id='A.10.1.1',
-            name='Test Component',
-        )
-
-    def test_serializer_creates_fragility_model_with_valid_component(self):
-        """Test that serializer successfully validates and saves with a valid component ID."""
+    def test_serializer_creates_fragility_model(self):
+        """Test that serializer successfully validates and saves a fragility model."""
         valid_data = {
             'id': 'test-fm-001',
-            'component': 'A.10.1.1',
             'comp_description': 'Test fragility model description',
         }
 
@@ -441,25 +435,15 @@ class FragilityModelSerializerTest(TestCase):
 
         self.assertIsNotNone(fragility_model)
         self.assertEqual(fragility_model.id, 'test-fm-001')
-        self.assertEqual(fragility_model.component.component_id, 'A.10.1.1')
 
-    def test_serializer_rejects_nonexistent_component(self):
-        """Test that serializer rejects data with a non-existent component ID."""
-        invalid_data = {
-            'id': 'test-fm-002',
-            'component': 'Z.99.9.9',
-            'comp_description': 'Test fragility model description',
-        }
-
-        serializer = FragilityModelSerializer(data=invalid_data)
-
-        self.assertFalse(serializer.is_valid())
-        self.assertIn('component', serializer.errors)
+    def test_serializer_excludes_component_field(self):
+        """Test that the serializer does not include a component field."""
+        serializer = FragilityModelSerializer()
+        self.assertNotIn('component', serializer.fields)
 
     def tearDown(self):
         """Clean up test data after each test."""
         FragilityModel.objects.filter(id__startswith='test-fm-').delete()
-        Component.objects.filter(component_id='A.10.1.1').delete()
 
 
 class ExperimentSerializerTest(TestCase):
@@ -569,7 +553,6 @@ class ExperimentFragilityModelBridgeSerializerTest(TestCase):
 
         self.fragility_model = FragilityModel.objects.create(
             id='test-fm-001',
-            component=self.component,
             comp_description='Test fragility model',
         )
 
@@ -622,8 +605,8 @@ class ExperimentFragilityModelBridgeSerializerTest(TestCase):
         Component.objects.filter(component_id='A.10.1.1').delete()
 
 
-class FragilityCurveSerializerTest(TestCase):
-    """Test cases for the FragilityCurveSerializer, focusing on foreign key validation."""
+class ComponentFragilityModelBridgeSerializerTest(TestCase):
+    """Test cases for the ComponentFragilityModelBridgeSerializer, focusing on foreign key validation."""
 
     def setUp(self):
         """Set up test data."""
@@ -632,6 +615,63 @@ class FragilityCurveSerializerTest(TestCase):
             name='Test Component',
         )
 
+        self.fragility_model = FragilityModel.objects.create(
+            id='test-fm-001',
+            comp_description='Test fragility model',
+        )
+
+    def test_serializer_creates_bridge_with_valid_foreign_keys(self):
+        """Test that serializer successfully validates and saves with valid component and fragility_model IDs."""
+        valid_data = {
+            'component': 'A.10.1.1',
+            'fragility_model': 'test-fm-001',
+        }
+
+        serializer = ComponentFragilityModelBridgeSerializer(data=valid_data)
+
+        self.assertTrue(serializer.is_valid())
+        bridge = serializer.save()
+
+        self.assertIsNotNone(bridge)
+        self.assertEqual(bridge.component.component_id, 'A.10.1.1')
+        self.assertEqual(bridge.fragility_model.id, 'test-fm-001')
+
+    def test_serializer_rejects_nonexistent_component(self):
+        """Test that serializer rejects data with a non-existent component ID."""
+        invalid_data = {
+            'component': 'Z.99.9.9',
+            'fragility_model': 'test-fm-001',
+        }
+
+        serializer = ComponentFragilityModelBridgeSerializer(data=invalid_data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('component', serializer.errors)
+
+    def test_serializer_rejects_nonexistent_fragility_model(self):
+        """Test that serializer rejects data with a non-existent fragility_model ID."""
+        invalid_data = {
+            'component': 'A.10.1.1',
+            'fragility_model': 'nonexistent-fm',
+        }
+
+        serializer = ComponentFragilityModelBridgeSerializer(data=invalid_data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('fragility_model', serializer.errors)
+
+    def tearDown(self):
+        """Clean up test data after each test."""
+        ComponentFragilityModelBridge.objects.all().delete()
+        FragilityModel.objects.filter(id__startswith='test-fm-').delete()
+        Component.objects.filter(component_id='A.10.1.1').delete()
+
+
+class FragilityCurveSerializerTest(TestCase):
+    """Test cases for the FragilityCurveSerializer, focusing on foreign key validation."""
+
+    def setUp(self):
+        """Set up test data."""
         self.reference = Reference.objects.create(
             id='test-ref-001',
             csl_data={
@@ -645,7 +685,6 @@ class FragilityCurveSerializerTest(TestCase):
 
         self.fragility_model = FragilityModel.objects.create(
             id='test-fm-001',
-            component=self.component,
             comp_description='Test fragility model',
         )
 
@@ -712,4 +751,3 @@ class FragilityCurveSerializerTest(TestCase):
         FragilityCurve.objects.all().delete()
         FragilityModel.objects.filter(id__startswith='test-fm-').delete()
         Reference.objects.filter(id__startswith='test-ref-').delete()
-        Component.objects.filter(component_id='A.10.1.1').delete()

--- a/ned_app/tests/test_data_integrity.py
+++ b/ned_app/tests/test_data_integrity.py
@@ -150,6 +150,10 @@ class DataIntegrityTests(TransactionTestCase):
                 'component.json': lambda x: x['component_id'],
                 'fragility_model.json': lambda x: x['id'],
                 'experiment.json': lambda x: x['id'],
+                'component_fragility_model_bridge.json': lambda x: (
+                    x['component'],
+                    x['fragility_model'],
+                ),
                 'experiment_fragility_model_bridge.json': lambda x: (
                     x['experiment'],
                     x['fragility_model'],

--- a/resources/data/component_fragility_model_bridge.json
+++ b/resources/data/component_fragility_model_bridge.json
@@ -1,0 +1,2046 @@
+[
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1001"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1002"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1003"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1004"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1005"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1006"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1007"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1008"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1009"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1010"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1011"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1012"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1013"
+    },
+    {
+        "component": "D.40.1.1.C",
+        "fragility_model": "fra1014"
+    },
+    {
+        "component": "D.40.1.1.E",
+        "fragility_model": "fra1015"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1016"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1017"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1018"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1019"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1020"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1021"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1022"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1023"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1024"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1025"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1026"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "fra1027"
+    },
+    {
+        "component": "D.40.1.1.F",
+        "fragility_model": "fra1028"
+    },
+    {
+        "component": "D.40.1.1.G",
+        "fragility_model": "fra1029"
+    },
+    {
+        "component": "D.40.1.1.F",
+        "fragility_model": "fra1030"
+    },
+    {
+        "component": "B.20.1.1.A",
+        "fragility_model": "B2011.001a"
+    },
+    {
+        "component": "B.20.1.1.A",
+        "fragility_model": "B2011.001b"
+    },
+    {
+        "component": "B.20.1.1.A",
+        "fragility_model": "B2011.011a"
+    },
+    {
+        "component": "B.20.1.1.A",
+        "fragility_model": "B2011.011b"
+    },
+    {
+        "component": "B.20.1.1.A",
+        "fragility_model": "B2011.021a"
+    },
+    {
+        "component": "B.20.1.1.A",
+        "fragility_model": "B2011.021b"
+    },
+    {
+        "component": "B.20.1.1.B",
+        "fragility_model": "B2011.101"
+    },
+    {
+        "component": "B.20.1.1.B",
+        "fragility_model": "B2011.102"
+    },
+    {
+        "component": "B.20.1.1.B",
+        "fragility_model": "B2011.111"
+    },
+    {
+        "component": "B.20.1.1.B",
+        "fragility_model": "B2011.121"
+    },
+    {
+        "component": "B.20.1.1.B",
+        "fragility_model": "B2011.131"
+    },
+    {
+        "component": "B.20.1.1.C",
+        "fragility_model": "B2011.201a"
+    },
+    {
+        "component": "B.20.1.1.C",
+        "fragility_model": "B2011.201b"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.001"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.002"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.011"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.021"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.022"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.023"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.031"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.032"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.033"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.034"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.035"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.036"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.037"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.038"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.039"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.040"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.041"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.051"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.052"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.053"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.054"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.061"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.071"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.072"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.081"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.082"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.083"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.084"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.091"
+    },
+    {
+        "component": "B.20.2.2.A",
+        "fragility_model": "B2022.101"
+    },
+    {
+        "component": "B.20.2.2.C",
+        "fragility_model": "B2022.201"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.001"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.002"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.011"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.021"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.031"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.032"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.033"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.034"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.041"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.051"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.052"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.053"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.054"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.055"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.056"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.057"
+    },
+    {
+        "component": "B.20.2.3.A",
+        "fragility_model": "B2023.058"
+    },
+    {
+        "component": "B.30.1.1.A",
+        "fragility_model": "B3011.011"
+    },
+    {
+        "component": "B.30.1.1.B",
+        "fragility_model": "B3011.012"
+    },
+    {
+        "component": "B.30.1.1.A",
+        "fragility_model": "B3011.013"
+    },
+    {
+        "component": "B.30.1.1.B",
+        "fragility_model": "B3011.014"
+    },
+    {
+        "component": "B.20.1.2.A",
+        "fragility_model": "B3031.001a"
+    },
+    {
+        "component": "B.20.1.2.A",
+        "fragility_model": "B3031.001b"
+    },
+    {
+        "component": "B.20.1.2.A",
+        "fragility_model": "B3031.001c"
+    },
+    {
+        "component": "B.20.1.2.A",
+        "fragility_model": "B3031.002a"
+    },
+    {
+        "component": "B.20.1.2.A",
+        "fragility_model": "B3031.002b"
+    },
+    {
+        "component": "B.20.1.2.A",
+        "fragility_model": "B3031.002c"
+    },
+    {
+        "component": "B.20.1.2.A",
+        "fragility_model": "B3041.001"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "C1011.001a"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "C1011.001b"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "C1011.001c"
+    },
+    {
+        "component": "C.10.1.1.A",
+        "fragility_model": "C1011.001d"
+    },
+    {
+        "component": "C.10.1.1.B",
+        "fragility_model": "C1011.011a"
+    },
+    {
+        "component": "C.20.1.1.A",
+        "fragility_model": "C2011.001a"
+    },
+    {
+        "component": "C.20.1.1.A",
+        "fragility_model": "C2011.001b"
+    },
+    {
+        "component": "C.20.1.1.B",
+        "fragility_model": "C2011.011a"
+    },
+    {
+        "component": "C.20.1.1.B",
+        "fragility_model": "C2011.011b"
+    },
+    {
+        "component": "C.20.1.1.C",
+        "fragility_model": "C2011.021a"
+    },
+    {
+        "component": "C.20.1.1.C",
+        "fragility_model": "C2011.021b"
+    },
+    {
+        "component": "C.20.1.1.C",
+        "fragility_model": "C2011.021c"
+    },
+    {
+        "component": "C.20.1.1.C",
+        "fragility_model": "C2011.021d"
+    },
+    {
+        "component": "C.20.1.1.D",
+        "fragility_model": "C2011.031a"
+    },
+    {
+        "component": "C.20.1.1.D",
+        "fragility_model": "C2011.031b"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.001a"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.001b"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.001c"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.001d"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.002a"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.002b"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.002c"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.002d"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.003a"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.003b"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.003c"
+    },
+    {
+        "component": "C.30.1.2.A",
+        "fragility_model": "C3011.003d"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001a"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001b"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001c"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001d"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001e"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001f"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001g"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001h"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001i"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001j"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001k"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001l"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001m"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001n"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001o"
+    },
+    {
+        "component": "C.30.2.1.A",
+        "fragility_model": "C3021.001p"
+    },
+    {
+        "component": "C.30.2.7.A",
+        "fragility_model": "C3027.001"
+    },
+    {
+        "component": "C.30.2.7.A",
+        "fragility_model": "C3027.002"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.001a"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.001b"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.001c"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.001d"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.003a"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.003b"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.003c"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.003d"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.004a"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.004b"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.004c"
+    },
+    {
+        "component": "C.30.3.2.A",
+        "fragility_model": "C3032.004d"
+    },
+    {
+        "component": "D.50.2.2.A",
+        "fragility_model": "C3034.001"
+    },
+    {
+        "component": "D.50.2.2.A",
+        "fragility_model": "C3034.002"
+    },
+    {
+        "component": "D.10.1.1.A",
+        "fragility_model": "D1014.011"
+    },
+    {
+        "component": "D.10.1.1.A",
+        "fragility_model": "D1014.012"
+    },
+    {
+        "component": "D.10.1.1.B",
+        "fragility_model": "D1014.021"
+    },
+    {
+        "component": "D.10.1.1.B",
+        "fragility_model": "D1014.022"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.023a"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.023b"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.024a"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.024b"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.011a"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.011b"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.011c"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.011d"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012a"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012b"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012c"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012d"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012e"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012f"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012g"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012h"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012i"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012j"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012k"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.012l"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013a"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013b"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013c"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013d"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013e"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013f"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013g"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013h"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013i"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013j"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013k"
+    },
+    {
+        "component": "D.30.3.1.A",
+        "fragility_model": "D3031.013l"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.021a"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.021b"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.021c"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.021d"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022a"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022b"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022c"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022d"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022e"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022f"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022g"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022h"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022i"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022j"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022k"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.022l"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023a"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023b"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023c"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023d"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023e"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023f"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023g"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023h"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023i"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023j"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023k"
+    },
+    {
+        "component": "D.30.3.1.B",
+        "fragility_model": "D3031.023l"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.011a"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.011b"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.011c"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.011d"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012a"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012b"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012c"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012d"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012e"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012f"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012g"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012h"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012i"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012j"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012k"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.012l"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013a"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013b"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013c"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013d"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013e"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013f"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013g"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013h"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013i"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013j"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013k"
+    },
+    {
+        "component": "D.30.3.2.A",
+        "fragility_model": "D3032.013l"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.001a"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.001b"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.001c"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.001d"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.002a"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.002b"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.002c"
+    },
+    {
+        "component": "D.30.4.1.C",
+        "fragility_model": "D3041.002d"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.011a"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.011b"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.011c"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.011d"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.012a"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.012b"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.012c"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.012d"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.021a"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.021b"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.021c"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.021d"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.022a"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.022b"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.022c"
+    },
+    {
+        "component": "D.30.4.1.A",
+        "fragility_model": "D3041.022d"
+    },
+    {
+        "component": "D.30.4.1.B",
+        "fragility_model": "D3041.031a"
+    },
+    {
+        "component": "D.30.4.1.B",
+        "fragility_model": "D3041.031b"
+    },
+    {
+        "component": "D.30.4.1.B",
+        "fragility_model": "D3041.032a"
+    },
+    {
+        "component": "D.30.4.1.B",
+        "fragility_model": "D3041.032b"
+    },
+    {
+        "component": "D.30.4.1.B",
+        "fragility_model": "D3041.032c"
+    },
+    {
+        "component": "D.30.4.1.B",
+        "fragility_model": "D3041.032d"
+    },
+    {
+        "component": "D.30.4.1.D",
+        "fragility_model": "D3041.041a"
+    },
+    {
+        "component": "D.30.4.1.D",
+        "fragility_model": "D3041.041b"
+    },
+    {
+        "component": "D.30.4.2.A",
+        "fragility_model": "D3041.101a"
+    },
+    {
+        "component": "D.30.4.2.A",
+        "fragility_model": "D3041.102a"
+    },
+    {
+        "component": "D.30.4.2.A",
+        "fragility_model": "D3041.102b"
+    },
+    {
+        "component": "D.30.4.2.A",
+        "fragility_model": "D3041.102c"
+    },
+    {
+        "component": "D.30.4.2.A",
+        "fragility_model": "D3041.103a"
+    },
+    {
+        "component": "D.30.4.2.A",
+        "fragility_model": "D3041.103b"
+    },
+    {
+        "component": "D.30.4.2.A",
+        "fragility_model": "D3041.103c"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.011a"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.011b"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.011c"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.011d"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013a"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013b"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013c"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013d"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013e"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013f"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013g"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013h"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013i"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013j"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013k"
+    },
+    {
+        "component": "D.30.5.2.A",
+        "fragility_model": "D3052.013l"
+    },
+    {
+        "component": "D.30.6.7.A",
+        "fragility_model": "D3067.011a"
+    },
+    {
+        "component": "D.30.6.7.A",
+        "fragility_model": "D3067.012a"
+    },
+    {
+        "component": "D.30.6.7.A",
+        "fragility_model": "D3067.012b"
+    },
+    {
+        "component": "D.30.6.7.A",
+        "fragility_model": "D3067.012c"
+    },
+    {
+        "component": "D.40.1.1.A",
+        "fragility_model": "D4011.021a"
+    },
+    {
+        "component": "D.40.1.1.A",
+        "fragility_model": "D4011.022a"
+    },
+    {
+        "component": "D.40.1.1.A",
+        "fragility_model": "D4011.023a"
+    },
+    {
+        "component": "D.40.1.1.A",
+        "fragility_model": "D4011.024a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.031a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.032a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.033a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.034a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.041a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.042a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.053a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.054a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.063a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.064a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.071a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.072a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.073a"
+    },
+    {
+        "component": "D.40.1.1.B",
+        "fragility_model": "D4011.074a"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.011a"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.011b"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.011c"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.011d"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013a"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013b"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013c"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013d"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013e"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013f"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013g"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013h"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013i"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013j"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013k"
+    },
+    {
+        "component": "D.50.1.1.A",
+        "fragility_model": "D5011.013l"
+    },
+    {
+        "component": "D.50.1.2.A",
+        "fragility_model": "D5012.013a"
+    },
+    {
+        "component": "D.50.1.2.A",
+        "fragility_model": "D5012.013b"
+    },
+    {
+        "component": "D.50.1.2.A",
+        "fragility_model": "D5012.013c"
+    },
+    {
+        "component": "D.50.1.2.A",
+        "fragility_model": "D5012.013d"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.021a"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.021b"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.021c"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.021d"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023a"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023b"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023c"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023d"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023e"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023f"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023g"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023h"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023i"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023j"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023k"
+    },
+    {
+        "component": "D.50.1.2.B",
+        "fragility_model": "D5012.023l"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.031a"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.031b"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.031c"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.031d"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033a"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033b"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033c"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033d"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033e"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033f"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033g"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033h"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033i"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033j"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033k"
+    },
+    {
+        "component": "D.50.1.2.C",
+        "fragility_model": "D5012.033l"
+    },
+    {
+        "component": "D.50.9.2.A",
+        "fragility_model": "D5092.011a"
+    },
+    {
+        "component": "D.50.9.2.A",
+        "fragility_model": "D5092.013a"
+    },
+    {
+        "component": "D.50.9.2.A",
+        "fragility_model": "D5092.013b"
+    },
+    {
+        "component": "D.50.9.2.A",
+        "fragility_model": "D5092.013c"
+    },
+    {
+        "component": "D.50.9.2.B",
+        "fragility_model": "D5092.021a"
+    },
+    {
+        "component": "D.50.9.2.B",
+        "fragility_model": "D5092.023a"
+    },
+    {
+        "component": "D.50.9.2.B",
+        "fragility_model": "D5092.023b"
+    },
+    {
+        "component": "D.50.9.2.B",
+        "fragility_model": "D5092.023c"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.031a"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.031b"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.031c"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.031d"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032a"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032b"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032c"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032d"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032e"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032f"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032g"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032h"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032i"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032j"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032k"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.032l"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033a"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033b"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033c"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033d"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033e"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033f"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033g"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033h"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033i"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033j"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033k"
+    },
+    {
+        "component": "D.50.9.2.C",
+        "fragility_model": "D5092.033l"
+    },
+    {
+        "component": "E.20.2.2.A",
+        "fragility_model": "E2022.001"
+    },
+    {
+        "component": "E.20.2.2.B",
+        "fragility_model": "E2022.010"
+    },
+    {
+        "component": "E.20.2.2.B",
+        "fragility_model": "E2022.011"
+    },
+    {
+        "component": "E.20.2.2.B",
+        "fragility_model": "E2022.012"
+    },
+    {
+        "component": "E.20.2.2.B",
+        "fragility_model": "E2022.013"
+    },
+    {
+        "component": "E.20.2.2.C",
+        "fragility_model": "E2022.020"
+    },
+    {
+        "component": "E.20.2.2.C",
+        "fragility_model": "E2022.021"
+    },
+    {
+        "component": "E.20.2.2.C",
+        "fragility_model": "E2022.022"
+    },
+    {
+        "component": "E.20.2.2.C",
+        "fragility_model": "E2022.023"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.102a"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.102b"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.103a"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.103b"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.104a"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.104b"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.105a"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.105b"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.106a"
+    },
+    {
+        "component": "E.20.2.2.D",
+        "fragility_model": "E2022.106b"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.112a"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.112b"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.114a"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.114b"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.124a"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.124b"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.125a"
+    },
+    {
+        "component": "E.20.2.2.E",
+        "fragility_model": "E2022.125b"
+    },
+    {
+        "component": "F.10.1.2.A",
+        "fragility_model": "F1012.001"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.011a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.011b"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.012a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.012b"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.013a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.013b"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.014a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.014b"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.021a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.022a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.023a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.023b"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.024a"
+    },
+    {
+        "component": "D.20.2.2.A",
+        "fragility_model": "D2021.024b"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.011a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.011b"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.012a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.012b"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.013a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.013b"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.014a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.014b"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.021a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.022a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.023a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.023b"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.024a"
+    },
+    {
+        "component": "D.30.4.4.A",
+        "fragility_model": "D2022.024b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.011b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.012b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.013b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.014b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.021a"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.021b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.022a"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.022b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.023a"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.023b"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.024a"
+    },
+    {
+        "component": "D.20.3.1.A",
+        "fragility_model": "D2031.024b"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.011a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.011b"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.012a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.012b"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.013a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.013b"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.014a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.014b"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.021a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.021b"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.022a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.023a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.023b"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.024a"
+    },
+    {
+        "component": "D.30.4.5.A",
+        "fragility_model": "D2051.024b"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.011a"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.011b"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.012a"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.012b"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.013a"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.013b"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.014a"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.014b"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.021a"
+    },
+    {
+        "component": "D.30.4.3.A",
+        "fragility_model": "D2061.022a"
+    }
+]

--- a/resources/data/fragility_model.json
+++ b/resources/data/fragility_model.json
@@ -2,7 +2,6 @@
     {
         "comp_description": "Component level - Tee joint - Black Iron with Threaded Joints - Pipe size 6 inches, 40 psi",
         "comp_detail": "Threaded joint",
-        "component": "D.40.1.1.C",
         "id": "fra1001",
         "material": "Black Iron",
         "p58_fragility": "",
@@ -11,7 +10,6 @@
     {
         "comp_description": "Component level - Tee joint - Black Iron with Threaded Joints - Pipe size 4 inches, 40 psi",
         "comp_detail": "Threaded joint",
-        "component": "D.40.1.1.C",
         "id": "fra1002",
         "material": "Black Iron",
         "p58_fragility": "",
@@ -20,7 +18,6 @@
     {
         "comp_description": "Component level - Tee joint - Black Iron with Threaded Joints - Pipe size 2 inches, 40 psi",
         "comp_detail": "Threaded joint",
-        "component": "D.40.1.1.C",
         "id": "fra1003",
         "material": "Black Iron",
         "p58_fragility": "",
@@ -29,7 +26,6 @@
     {
         "comp_description": "Component level - Tee joint - Black Iron with Threaded Joints - Pipe size 1 inches, 40 psi",
         "comp_detail": "Threaded joint",
-        "component": "D.40.1.1.C",
         "id": "fra1004",
         "material": "Black Iron",
         "p58_fragility": "",
@@ -38,7 +34,6 @@
     {
         "comp_description": "Component level - Tee joint - Black Iron with Threaded Joints - Pipe size 3/4 inches, 40 psi",
         "comp_detail": "Threaded joint",
-        "component": "D.40.1.1.C",
         "id": "fra1005",
         "material": "Black Iron",
         "p58_fragility": "",
@@ -47,7 +42,6 @@
     {
         "comp_description": "Component level - Tee joint - CPVC with Cement Joint - Pipe size 2 inches, 40 psi",
         "comp_detail": "Cement joint",
-        "component": "D.40.1.1.C",
         "id": "fra1006",
         "material": "CPVC",
         "p58_fragility": "",
@@ -56,7 +50,6 @@
     {
         "comp_description": "Component level - Tee joint - CPVC with Cement Joint - Pipe size 1 inches, 40 psi",
         "comp_detail": "Cement joint",
-        "component": "D.40.1.1.C",
         "id": "fra1007",
         "material": "CPVC",
         "p58_fragility": "",
@@ -65,7 +58,6 @@
     {
         "comp_description": "Component level - Tee joint - CPVC with Cement Joint - Pipe size 3/4 inches, 40 psi",
         "comp_detail": "Cement joint",
-        "component": "D.40.1.1.C",
         "id": "fra1008",
         "material": "CPVC",
         "p58_fragility": "",
@@ -74,7 +66,6 @@
     {
         "comp_description": "Component level - Tee joint - Schedule 40 Steel with Groove Fit Connections - Pipe size 4 inches, 40 psi",
         "comp_detail": "Grooved coupling",
-        "component": "D.40.1.1.C",
         "id": "fra1009",
         "material": "Steel",
         "p58_fragility": "",
@@ -83,7 +74,6 @@
     {
         "comp_description": "Component level - Tee joint - Schedule 40 Steel with Groove Fit Connections - Pipe size 2 inches, 40 psi",
         "comp_detail": "Grooved coupling",
-        "component": "D.40.1.1.C",
         "id": "fra1010",
         "material": "Steel",
         "p58_fragility": "",
@@ -92,7 +82,6 @@
     {
         "comp_description": "Component level - Tee joint - Schedule 10 Steel with Groove Fit Connections - Pipe size 4 inches, 40 psi",
         "comp_detail": "Grooved coupling",
-        "component": "D.40.1.1.C",
         "id": "fra1011",
         "material": "Steel",
         "p58_fragility": "",
@@ -101,7 +90,6 @@
     {
         "comp_description": "Component level - Tee joint - Schedule 10 Steel with Groove Fit Connections - Pipe size 2 inches, 40 psi",
         "comp_detail": "Grooved coupling",
-        "component": "D.40.1.1.C",
         "id": "fra1012",
         "material": "Steel",
         "p58_fragility": "",
@@ -110,7 +98,6 @@
     {
         "comp_description": "Component level - Tee joint - two 6\" (DN150) galvanized steel pipe connected to one 3.14\" (DN80) pipe - Cast iron lathedog-plumbings and grooved fit pipe joints, 232 psi (1.6 Mpa)",
         "comp_detail": "Grooved coupling",
-        "component": "D.40.1.1.C",
         "id": "fra1013",
         "material": "Steel",
         "p58_fragility": "",
@@ -119,7 +106,6 @@
     {
         "comp_description": "Component level - Tee joint - two 6\" (DN150) galvanized steel pipe connected to one 3.14\" (DN80) pipe - Cast iron lathedog-plumbings and grooved fit pipe joints, 232 psi (1.6 Mpa)",
         "comp_detail": "Grooved coupling",
-        "component": "D.40.1.1.C",
         "id": "fra1014",
         "material": "Steel",
         "p58_fragility": "",
@@ -128,7 +114,6 @@
     {
         "comp_description": "Component level - 90 degree elbow joint connected with two 6\" (DN150) galvanized steel pipe  Cast iron lathedog-plumbings and grooved fit pipe joints, 232 psi (1.6 Mpa)",
         "comp_detail": "Grooved coupling",
-        "component": "D.40.1.1.E",
         "id": "fra1015",
         "material": "Steel",
         "p58_fragility": "",
@@ -137,7 +122,6 @@
     {
         "comp_description": "The indoor partition wall is surrounded by structural elements on all sides, fixed on all sides",
         "comp_detail": "Fixed",
-        "component": "C.10.1.1.A",
         "id": "fra1016",
         "material": "",
         "p58_fragility": "",
@@ -146,7 +130,6 @@
     {
         "comp_description": "The indoor partition wall is surrounded by structural elements on all sides, sliding connections on either horizontal or both horizontal and vertical  sides",
         "comp_detail": "Sliding connection",
-        "component": "C.10.1.1.A",
         "id": "fra1017",
         "material": "",
         "p58_fragility": "",
@@ -155,7 +138,6 @@
     {
         "comp_description": "The indoor partition wall is surrounded by structural elements at top and bottom, fixed connection at horizontal sides",
         "comp_detail": "Fixed",
-        "component": "C.10.1.1.A",
         "id": "fra1018",
         "material": "",
         "p58_fragility": "",
@@ -164,7 +146,6 @@
     {
         "comp_description": "The indoor partition wall is surrounded by structural elements at top and bottom, sliding connection at horizontal sides",
         "comp_detail": "Sliding connection",
-        "component": "C.10.1.1.A",
         "id": "fra1019",
         "material": "",
         "p58_fragility": "",
@@ -173,7 +154,6 @@
     {
         "comp_description": "Full-height commercial-slip tracks: Specimens 1-3, 31, and 32;",
         "comp_detail": "Full height - Slip track",
-        "component": "C.10.1.1.A",
         "id": "fra1020",
         "material": "",
         "p58_fragility": "",
@@ -182,7 +162,6 @@
     {
         "comp_description": "Full-height commercial-partial/full\nconnections:Specimens 4-10",
         "comp_detail": "Full height",
-        "component": "C.10.1.1.A",
         "id": "fra1021",
         "material": "",
         "p58_fragility": "",
@@ -191,7 +170,6 @@
     {
         "comp_description": "Full-height commercial-all",
         "comp_detail": "Full height",
-        "component": "C.10.1.1.A",
         "id": "fra1022",
         "material": "",
         "p58_fragility": "",
@@ -200,7 +178,6 @@
     {
         "comp_description": "Full-height institutional-slip tracks: Specimens 20-22;",
         "comp_detail": "Full height - Slip track",
-        "component": "C.10.1.1.A",
         "id": "fra1023",
         "material": "",
         "p58_fragility": "",
@@ -209,7 +186,6 @@
     {
         "comp_description": "Full-height institutional partial/full\nconnections: Specimens 23-28",
         "comp_detail": "Full height",
-        "component": "C.10.1.1.A",
         "id": "fra1024",
         "material": "",
         "p58_fragility": "",
@@ -218,7 +194,6 @@
     {
         "comp_description": "Full-height institutional-all",
         "comp_detail": "Full height",
-        "component": "C.10.1.1.A",
         "id": "fra1025",
         "material": "",
         "p58_fragility": "",
@@ -227,7 +202,6 @@
     {
         "comp_description": "Partial-height: Specimens 17-19 and 48-50",
         "comp_detail": "Partial height",
-        "component": "C.10.1.1.A",
         "id": "fra1026",
         "material": "",
         "p58_fragility": "",
@@ -236,7 +210,6 @@
     {
         "comp_description": "Improved corner details: Specimens 33-36.",
         "comp_detail": "",
-        "component": "C.10.1.1.A",
         "id": "fra1027",
         "material": "",
         "p58_fragility": "",
@@ -245,7 +218,6 @@
     {
         "comp_description": "\u215b-inch diameter galvanized 7 x 19 (number of strands x wires per strand) aircraft-grade steel with a specified minimum break strength of 1700 pounds,\nThe cable support was threaded, and a screw was clamped on top.",
         "comp_detail": "",
-        "component": "D.40.1.1.F",
         "id": "fra1028",
         "material": "",
         "p58_fragility": "",
@@ -254,7 +226,6 @@
     {
         "comp_description": "5/8 in dia rods - pipe hangers",
         "comp_detail": "",
-        "component": "D.40.1.1.G",
         "id": "fra1029",
         "material": "",
         "p58_fragility": "",
@@ -263,7 +234,6 @@
     {
         "comp_description": "gauge 12 wire restrainers",
         "comp_detail": "",
-        "component": "D.40.1.1.F",
         "id": "fra1030",
         "material": "",
         "p58_fragility": "",
@@ -272,7 +242,6 @@
     {
         "comp_description": "Exterior Wall - Cold formed steel walls with wood structural panel sheathing, interior - gypsum board - Costing for each 100 ft^2 Wall Panel. Assumed framing: 38 mil cold formed steel framing with 7/16 OSB and 3/8 plywood panel sheathing with overturning restraint at each end of the wall per AISI design standard. No. 8 screws 2\" to 6\" OC at perimeter and 12\" OC EW in field.",
         "comp_detail": "Wood structural panel sheathing",
-        "component": "B.20.1.1.A",
         "id": "B2011.001a",
         "material": "Cold-formed steel",
         "p58_fragility": "B2011.001a",
@@ -281,7 +250,6 @@
     {
         "comp_description": "Exterior Wall - Cold formed steel walls with wood structural panel sheathing, exterior - stucco one side - Costing for each 100 ft^2 Wall Panel. Assumed framing: 38 mil cold formed steel framing with 7/16 OSB and 3/8 plywood panel sheathing with overturning restraint at each end of the wall per AISI design standard. No. 8 screws 2\" to 6\" OC at perimeter and 12\" OC EW in field.",
         "comp_detail": "Wood structural panel sheathing",
-        "component": "B.20.1.1.A",
         "id": "B2011.001b",
         "material": "Cold-formed steel with stucco",
         "p58_fragility": "B2011.001b",
@@ -290,7 +258,6 @@
     {
         "comp_description": "Exterior Wall - Cold formed steel walls with flat strap X-bracing, interior - gypsum board - Costing for each 100 ft^2 Wall Panel. Assumed framing: 33 mil cold formed steel framing with 4.5 inch x 33 mil flat strap X-bracing on one side. Straps attached to gussets with No. 8 screws.",
         "comp_detail": "X-bracing",
-        "component": "B.20.1.1.A",
         "id": "B2011.011a",
         "material": "Cold-formed steel",
         "p58_fragility": "B2011.011a",
@@ -299,7 +266,6 @@
     {
         "comp_description": "Exterior Wall - Cold formed steel walls with flat strap X-bracing, exterior - stucco one side - Costing for each 100 ft^2 Wall Panel. Assumed framing: 33 mil cold formed steel framing with 4.5 inch x 33 mil flat strap X-bracing on one side. Straps attached to gussets with No. 8 screws.",
         "comp_detail": "X-bracing",
-        "component": "B.20.1.1.A",
         "id": "B2011.011b",
         "material": "Cold-formed steel with stucco",
         "p58_fragility": "B2011.011b",
@@ -308,7 +274,6 @@
     {
         "comp_description": "Exterior Wall - Cold formed steel walls with 22 or 31 mil steel sheathing, interior - gypsum board - Costing for each 100 ft^2 Wall Panel. Assumed framing: 33 mil cold formed steel framing with 22 or 31 mil steel sheathing attached with No. 8 screws spaced 2\" or 6\" OC at perimeter and 12\" OC EW in the field.",
         "comp_detail": "22 or 31 mil steel sheathing",
-        "component": "B.20.1.1.A",
         "id": "B2011.021a",
         "material": "Cold-formed steel",
         "p58_fragility": "B2011.021a",
@@ -317,7 +282,6 @@
     {
         "comp_description": "Exterior Wall - Cold formed steel walls with 22 or 31 mil steel sheathing, exterior - stucco one side - Costing for each 100 ft^2 Wall Panel. Assumed framing: 33 mil cold formed steel framing with 22 or 31 mil steel sheathing attached with No. 8 screws spaced 2\" or 6\" OC at perimeter and 12\" OC EW in the field.",
         "comp_detail": "22 or 31 mil steel sheathing",
-        "component": "B.20.1.1.A",
         "id": "B2011.021b",
         "material": "Cold-formed steel with stucco",
         "p58_fragility": "B2011.021b",
@@ -326,7 +290,6 @@
     {
         "comp_description": "Exterior Wall - Light framed wood walls with structural panel sheathing, gypsum wallboard no hold-downs - Costing for each 100 ft^2 Wall Panel. Assumed framing: 1 SIDE: 3/8\" OSB or 15/32 ply with 8d box nails at 4 to 6 inches along panel edges and 12 inches field nailing. DF #2, 2x4@16 studs. 1 SIDE: 1/2 gypsum board. Panel 8 feet tall, 8 or 16 feet long with or without door and window openings, double top plate, single bottom plate, no hold-downs.",
         "comp_detail": "Wood structural panel sheathing",
-        "component": "B.20.1.1.B",
         "id": "B2011.101",
         "material": "Light-framed wood",
         "p58_fragility": "B2011.101",
@@ -335,7 +298,6 @@
     {
         "comp_description": "Exterior Wall - Light framed wood walls with structural panel sheathing, stucco, hold-downs - Costing for each 100 ft^2 Wall Panel. Assumed framing: 1 SIDE: 3/8\" OSB or 15/32 ply with 8d box nails at 4 to 6 inches along panel edges and 12 inches field nailing. DF #2, 2x4@16 studs. 1 SIDE: 1/2 gypsum board. Panel 8 feet tall, 8 or 16 feet long with or without door and window openings, double top plate, single bottom plate, with hold-downs. Three layer 7/8\" stucco with 1/2-inch chop strand fibers applied over wire mesh fastened with 1.25 -inch long staples.",
         "comp_detail": "Wood structural panel sheathing with hold-downs",
-        "component": "B.20.1.1.B",
         "id": "B2011.102",
         "material": "Light-framed wood with stucco",
         "p58_fragility": "B2011.102",
@@ -344,7 +306,6 @@
     {
         "comp_description": "Exterior Wall - Light framed wood walls with structural panel sheathing, stucco no hold-downs - Costing for each 100 ft^2 Wall Panel. Assumed framing: 1 SIDE: 3/8\" OSB or 15/32 ply with 8d box nails at 4 to 6 inches along panel edges and 12 inches field nailing. DF #2, 2x4@16 studs. 1 SIDE: 1/2 gypsum board. Panel 8 feet tall, 8 or 16 feet long with or without door and window openings, double top plate, single bottom plate, with no hold-downs. Three layer 7/8\" stucco with 1/2-inch chop strand fibers applied over wire mesh fastened with 1.25 -inch long staples.",
         "comp_detail": "Wood structural panel sheathing",
-        "component": "B.20.1.1.B",
         "id": "B2011.111",
         "material": "Light-framed wood with stucco",
         "p58_fragility": "B2011.111",
@@ -353,7 +314,6 @@
     {
         "comp_description": "Exterior Wall - Light framed wood walls with structural panel sheathing, gypsum wallboard and hold-downs - Costing for each 100 ft^2 Wall Panel. Assumed framing: 1 SIDE: 3/8\" OSB or 15/32 ply with 8d box nails at 4 to 6 inches along panel edges and 12 inches field nailing. DF #2, 2x4@16 studs. 1 SIDE: 1/2 gypsum board. Panel 8 feet tall, 8 or 16 feet long with or without door and window openings, double top plate, single bottom plate, with hold-downs.",
         "comp_detail": "Wood structural panel sheathing with hold-downs",
-        "component": "B.20.1.1.B",
         "id": "B2011.121",
         "material": "Light-framed wood",
         "p58_fragility": "B2011.121",
@@ -362,7 +322,6 @@
     {
         "comp_description": "Exterior Wall - Wood walls with diagonal let-in bracing - Costing for each 100 ft^2 Wall Panel. Assumed framing: Stud wall framing consists of 2 x 4\u2019s at 16 inches on center with double top plates and single sill plate. Diagonal bracing includes 2 forms. Block-bracing consists of diagonal blocking between studs that extends from the top of one edge of the panel to the bottom of the opposite edge. Diagonal bracing may also consist of let-in bracing for which a 1x or 2x brace (with same inclination as described for block-bracing) is recessed into studs. Walls may be sheathed with horizontal or vertical lumber siding.",
         "comp_detail": "Let-in-bracing",
-        "component": "B.20.1.1.B",
         "id": "B2011.131",
         "material": "Light-framed wood",
         "p58_fragility": "B2011.131",
@@ -371,7 +330,6 @@
     {
         "comp_description": "Precast Concrete Panels 4.5 inches thick - in plane deformation - Costing is based upon 30'x13' panels.",
         "comp_detail": "",
-        "component": "B.20.1.1.C",
         "id": "B2011.201a",
         "material": "Reinforced concrete",
         "p58_fragility": "B2011.201a",
@@ -380,7 +338,6 @@
     {
         "comp_description": "Precast Concrete Panels 4.5 inches thick - out of plane deformation - Costing is based upon 30'x13' panels.",
         "comp_detail": "",
-        "component": "B.20.1.1.C",
         "id": "B2011.201b",
         "material": "Reinforced concrete",
         "p58_fragility": "B2011.201b",
@@ -389,7 +346,6 @@
     {
         "comp_description": "Curtain Walls - Generic Midrise Stick-Built Curtain wall, Config: Monolithic, Lamination: Unknown, Glass Type: Unknown, Details: Aspect ratio = 6:5, Other details Unknown - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.001",
         "material": "",
         "p58_fragility": "B2022.001",
@@ -398,7 +354,6 @@
     {
         "comp_description": "Curtain Walls - Generic Midrise Stick-Built Curtain wall, Config: Insulating Glass Units (dual pane), Lamination: Unknown, Glass Type: Unknown, Details: Aspect ratio = 6:5, Other details Unknown - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.002",
         "material": "",
         "p58_fragility": "B2022.002",
@@ -407,7 +362,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Asymmetric insulating glass units (dual-pane, unequal-thickness IGU), Lamination: Laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) inner AN / 1/2 in. (13 mm) outer AN LAM (0.030 PVB) IGU; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built",
-        "component": "B.20.2.2.A",
         "id": "B2022.011",
         "material": "Laminated and annealed",
         "p58_fragility": "B2022.011",
@@ -416,7 +370,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN LAM (0.030 PVB); glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.021",
         "material": "Laminated and annealed",
         "p58_fragility": "B2022.021",
@@ -425,7 +378,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN laminated, 2-sided SSG, Center Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.022",
         "material": "Laminated and annealed",
         "p58_fragility": "B2022.022",
@@ -434,7 +386,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN laminated, 2-sided SSG, Outside Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.023",
         "material": "Laminated and annealed",
         "p58_fragility": "B2022.023",
@@ -443,7 +394,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.031",
         "material": "Annealed",
         "p58_fragility": "B2022.031",
@@ -452,7 +402,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0 in. (0 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.032",
         "material": "Annealed",
         "p58_fragility": "B2022.032",
@@ -461,7 +410,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.13 in. (3 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.033",
         "material": "Annealed",
         "p58_fragility": "B2022.033",
@@ -470,7 +418,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.25 in. (6 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.034",
         "material": "Annealed",
         "p58_fragility": "B2022.034",
@@ -479,7 +426,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 2:1 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.035",
         "material": "Annealed",
         "p58_fragility": "B2022.035",
@@ -488,7 +434,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1:2 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.036",
         "material": "Annealed",
         "p58_fragility": "B2022.036",
@@ -497,7 +442,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic, 2-sided SSG, Center Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.037",
         "material": "Annealed",
         "p58_fragility": "B2022.037",
@@ -506,7 +450,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic, 2-sided SSG, Outside Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.038",
         "material": "Annealed",
         "p58_fragility": "B2022.038",
@@ -515,7 +458,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.039",
         "material": "Annealed",
         "p58_fragility": "B2022.039",
@@ -524,7 +466,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 2:1 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.040",
         "material": "Annealed",
         "p58_fragility": "B2022.040",
@@ -533,7 +474,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1:2 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.041",
         "material": "Annealed",
         "p58_fragility": "B2022.041",
@@ -542,7 +482,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 1/4 in. (6 mm) FT monolithic, 2-sided SSG, Center Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.051",
         "material": "Fully tempered",
         "p58_fragility": "B2022.051",
@@ -551,7 +490,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 1/4 in. (6 mm) FT monolithic, 2-sided SSG, Outside Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.052",
         "material": "Fully tempered",
         "p58_fragility": "B2022.052",
@@ -560,7 +498,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 1/4 in. (6 mm) FT monolithic, Seamed Edge; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.053",
         "material": "Fully tempered",
         "p58_fragility": "B2022.053",
@@ -569,7 +506,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 1/4 in. (6 mm) FT monolithic, Polished Edge; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.054",
         "material": "Fully tempered",
         "p58_fragility": "B2022.054",
@@ -578,7 +514,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Monolithic, Lamination: Not laminated, Glass Type: Heat strengthened, Details: 1/4 in. (6 mm) HS monolithic; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - monolithic",
-        "component": "B.20.2.2.A",
         "id": "B2022.061",
         "material": "Heat-strengthened",
         "p58_fragility": "B2022.061",
@@ -587,7 +522,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) inner AN / 1/4 in. (6 mm) outer AN LAM (0.030 PVB) IGU; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.071",
         "material": "Laminated and annealed",
         "p58_fragility": "B2022.071",
@@ -596,7 +530,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) inner AN / 1/4 in. (6 mm) outer AN LAM (0.060 PVB) IGU; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.072",
         "material": "Laminated and annealed",
         "p58_fragility": "B2022.072",
@@ -605,7 +538,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Annealed, Details: 1 in. (25 mm) AN insulating glass unit (IGU) [1/4 in. (6 mm) inner and outer panes]; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.081",
         "material": "Annealed",
         "p58_fragility": "B2022.081",
@@ -614,7 +546,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Annealed, Details: 1 in. (25 mm) AN IGU [1/4 in. (6 mm) inner and outer panes]; glass-frame clearance = 0.25 in. (6 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.082",
         "material": "Annealed",
         "p58_fragility": "B2022.082",
@@ -623,7 +554,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Annealed, Details: 1 in. (25 mm) AN IGU [1/4 in. (6 mm) inner and outer panes], 2-sided SSG, Center Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.083",
         "material": "Annealed",
         "p58_fragility": "B2022.083",
@@ -632,7 +562,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Annealed, Details: 1 in. (25 mm) AN IGU [1/4 in. (6 mm) inner and outer panes], 2-sided SSG, Outside Panel; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = wet - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.084",
         "material": "Annealed",
         "p58_fragility": "B2022.084",
@@ -641,7 +570,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes]; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.091",
         "material": "Fully tempered",
         "p58_fragility": "B2022.091",
@@ -650,7 +578,6 @@
     {
         "comp_description": "Midrise stick-built curtain wall, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Heat strengthened, Details: 1 in. (25 mm) HS IGU [1/4 in. (6 mm) inner and outer panes]; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Stick-built - insulating glass unit",
-        "component": "B.20.2.2.A",
         "id": "B2022.101",
         "material": "Heat-strengthened",
         "p58_fragility": "B2022.101",
@@ -659,7 +586,6 @@
     {
         "comp_description": "Curtain Walls - Unitized curtain wall (also generic unitized curtain wall), Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1-1/4 in. (32 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], 4-sided SSG, VHBTM SGTTM; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = Varies sealant = wet - None",
         "comp_detail": "Unitized",
-        "component": "B.20.2.2.C",
         "id": "B2022.201",
         "material": "Fully tempered",
         "p58_fragility": "B2022.201",
@@ -668,7 +594,6 @@
     {
         "comp_description": "Generic Storefront, Config: Monolithic, Lamination: Unknown, Glass Type: Unknown, Details: Aspect ratio = 6:5, Other details Unknown - None",
         "comp_detail": "Monolithic",
-        "component": "B.20.2.3.A",
         "id": "B2023.001",
         "material": "",
         "p58_fragility": "B2023.001",
@@ -677,7 +602,6 @@
     {
         "comp_description": "Generic Storefront, Config: IGU, Lamination: Unknown, Glass Type: Unknown, Details: Aspect ratio = 6:5, Other details Unknown - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.002",
         "material": "",
         "p58_fragility": "B2023.002",
@@ -686,7 +610,6 @@
     {
         "comp_description": "Storefront, Config: Monolithic, Lamination: Laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN LAM (0.030 PVB); glass-frame clearance = 0.41 in. (10 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Monolithic",
-        "component": "B.20.2.3.A",
         "id": "B2023.011",
         "material": "Laminated and annealed",
         "p58_fragility": "B2023.011",
@@ -695,7 +618,6 @@
     {
         "comp_description": "Storefront, Config: Monolithic, Lamination: Not laminated, Glass Type: Annealed, Details: 1/4 in. (6 mm) AN monolithic; glass-frame clearance = 0.41 in. (10 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Monolithic",
-        "component": "B.20.2.3.A",
         "id": "B2023.021",
         "material": "Annealed",
         "p58_fragility": "B2023.021",
@@ -704,7 +626,6 @@
     {
         "comp_description": "Storefront, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 3/8 in. (10 mm) FT monolithic, Planar Specimen; glass-frame clearance = 0.5 in. (13 mm); aspect ratio = 1.93:1 sealant = wet - None",
         "comp_detail": "Monolithic",
-        "component": "B.20.2.3.A",
         "id": "B2023.031",
         "material": "Annealed",
         "p58_fragility": "B2023.031",
@@ -713,7 +634,6 @@
     {
         "comp_description": "Storefront, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 3/8 in. (10 mm) FT monolithic, Corner Cond. Specimen, in-plane; glass-frame clearance = 0.5 in. (13 mm); aspect ratio = 1.93:1 sealant = wet - None",
         "comp_detail": "Monolithic",
-        "component": "B.20.2.3.A",
         "id": "B2023.032",
         "material": "Annealed",
         "p58_fragility": "B2023.032",
@@ -722,7 +642,6 @@
     {
         "comp_description": "Storefront, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 3/8 in. (10 mm) FT monolithic, Corner Cond. Specimen, combined; glass-frame clearance = 0.5 in. (13 mm); aspect ratio = 1.93:1 sealant = wet - None",
         "comp_detail": "Monolithic",
-        "component": "B.20.2.3.A",
         "id": "B2023.033",
         "material": "Annealed",
         "p58_fragility": "B2023.033",
@@ -731,7 +650,6 @@
     {
         "comp_description": "Storefront, Config: Monolithic, Lamination: Not laminated, Glass Type: Full tempered, Details: 3/8 in. (10 mm) FT monolithic, Corner Cond. Specimen, Short side; glass-frame clearance = 0.5 in. (13 mm); aspect ratio = 2.72:1 sealant = wet - None",
         "comp_detail": "Monolithic",
-        "component": "B.20.2.3.A",
         "id": "B2023.034",
         "material": "Annealed",
         "p58_fragility": "B2023.034",
@@ -740,7 +658,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Annealed, Details: 1 in. (25 mm) AN IGU; glass-frame clearance = 0.59 in. (15 mm); aspect ratio = 6:5 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.041",
         "material": "Annealed",
         "p58_fragility": "B2023.041",
@@ -749,7 +666,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Planar Specimen; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1.89:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.051",
         "material": "Fully tempered",
         "p58_fragility": "B2023.051",
@@ -758,7 +674,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Corner Cond. Specimen, in-plane; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1.89:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.052",
         "material": "Fully tempered",
         "p58_fragility": "B2023.052",
@@ -767,7 +682,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Corner Cond. Specimen, combined; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1.89:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.053",
         "material": "Fully tempered",
         "p58_fragility": "B2023.053",
@@ -776,7 +690,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Corner Cond. Specimen, Short side; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 2.83:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.054",
         "material": "Fully tempered",
         "p58_fragility": "B2023.054",
@@ -785,7 +698,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Planar Specimen; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1.88:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.055",
         "material": "Fully tempered",
         "p58_fragility": "B2023.055",
@@ -794,7 +706,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Corner Cond. Specimen, in-plane; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1.88:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.056",
         "material": "Fully tempered",
         "p58_fragility": "B2023.056",
@@ -803,7 +714,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Corner Cond. Specimen, combined; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 1.88:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.057",
         "material": "Fully tempered",
         "p58_fragility": "B2023.057",
@@ -812,7 +722,6 @@
     {
         "comp_description": "Storefront, Config: Symmetric insulating glass units (dual-pane, equal-thickness IGU), Lamination: Not laminated, Glass Type: Full tempered, Details: 1 in. (25 mm) FT IGU [1/4 in. (6 mm) inner and outer panes], Corner Cond. Specimen, Short side; glass-frame clearance = 0.43 in. (11 mm); aspect ratio = 2.82:1 sealant = dry - None",
         "comp_detail": "Insulating glass unit",
-        "component": "B.20.2.3.A",
         "id": "B2023.058",
         "material": "Fully tempered",
         "p58_fragility": "B2023.058",
@@ -821,7 +730,6 @@
     {
         "comp_description": "Concrete tile roof, tiles secured and compliant with UBC94 - Costing per roofing square (100 SF)",
         "comp_detail": "secured",
-        "component": "B.30.1.1.A",
         "id": "B3011.011",
         "material": "Concrete tile",
         "p58_fragility": "B3011.011",
@@ -830,7 +738,6 @@
     {
         "comp_description": "Clay tile roof, tiles secured and compliant with UBC94 - Costing per roofing square (100 SF)",
         "comp_detail": "secured",
-        "component": "B.30.1.1.B",
         "id": "B3011.012",
         "material": "Clay tile",
         "p58_fragility": "B3011.012",
@@ -839,7 +746,6 @@
     {
         "comp_description": "Concrete tile roof, unsecured tiles - Costing per roofing square (100 SF)",
         "comp_detail": "unsecured",
-        "component": "B.30.1.1.A",
         "id": "B3011.013",
         "material": "Concrete tile",
         "p58_fragility": "B3011.013",
@@ -848,7 +754,6 @@
     {
         "comp_description": "Clay tile roof, unsecured tiles - Costing per roofing square (100 SF)",
         "comp_detail": "unsecured",
-        "component": "B.30.1.1.B",
         "id": "B3011.014",
         "material": "Clay tile",
         "p58_fragility": "B3011.014",
@@ -857,7 +762,6 @@
     {
         "comp_description": "Masonry Chimney - unreinforced, non industrial, above roof 5 ft, replace with masonry - Demand parameter shall be defined as the first floor peak floor acceleration. Unreinforced masonry chimney as a component of wood frame buildings. Includes firebox and chimney, excludes exterior veneer or ornamentation. May include chimneys where the quality of reinforcing is unknown. For multiple story buildings enter the chimney fragility once at the first floor, do not specify this fragility at subsequent elevated floors.",
         "comp_detail": "Unreinforced - unbraced",
-        "component": "B.20.1.2.A",
         "id": "B3031.001a",
         "material": "Masonry",
         "p58_fragility": "B3031.001a",
@@ -866,7 +770,6 @@
     {
         "comp_description": "Masonry Chimney - unreinforced, non industrial, above roof 10 ft, replace with masonry - Demand parameter shall be defined as the first floor peak floor acceleration. Unreinforced masonry chimney as a component of wood frame buildings. Includes firebox and chimney, excludes exterior veneer or ornamentation. May include chimneys where the quality of reinforcing is unknown. For multiple story buildings enter the chimney fragility once at the first floor, do not specify this fragility at subsequent elevated floors.",
         "comp_detail": "Unreinforced - unbraced",
-        "component": "B.20.1.2.A",
         "id": "B3031.001b",
         "material": "Masonry",
         "p58_fragility": "B3031.001b",
@@ -875,7 +778,6 @@
     {
         "comp_description": "Masonry Chimney - unreinforced, non industrial, above roof 15 ft, replace with masonry - Demand parameter shall be defined as the first floor peak floor acceleration. Unreinforced masonry chimney as a component of wood frame buildings. Includes firebox and chimney, excludes exterior veneer or ornamentation. May include chimneys where the quality of reinforcing is unknown. For multiple story buildings enter the chimney fragility once at the first floor, do not specify this fragility at subsequent elevated floors.",
         "comp_detail": "Unreinforced - unbraced",
-        "component": "B.20.1.2.A",
         "id": "B3031.001c",
         "material": "Masonry",
         "p58_fragility": "B3031.001c",
@@ -884,7 +786,6 @@
     {
         "comp_description": "Masonry Chimney - unreinforced, non industrial, above roof 5 ft, replace with framing - Demand parameter shall be defined as the first floor peak floor acceleration. Unreinforced masonry chimney as a component of wood frame buildings. Includes firebox and chimney, excludes exterior veneer or ornamentation. May include chimneys where the quality of reinforcing is unknown. For multiple story buildings enter the chimney fragility once at the first floor, do not specify this fragility at subsequent elevated floors.",
         "comp_detail": "Unreinforced - unbraced",
-        "component": "B.20.1.2.A",
         "id": "B3031.002a",
         "material": "Masonry",
         "p58_fragility": "B3031.002a",
@@ -893,7 +794,6 @@
     {
         "comp_description": "Masonry Chimney - unreinforced, non industrial, above roof 10 ft, replace with framing - Demand parameter shall be defined as the first floor peak floor acceleration. Unreinforced masonry chimney as a component of wood frame buildings. Includes firebox and chimney, excludes exterior veneer or ornamentation. May include chimneys where the quality of reinforcing is unknown. For multiple story buildings enter the chimney fragility once at the first floor, do not specify this fragility at subsequent elevated floors.",
         "comp_detail": "Unreinforced - unbraced",
-        "component": "B.20.1.2.A",
         "id": "B3031.002b",
         "material": "Masonry",
         "p58_fragility": "B3031.002b",
@@ -902,7 +802,6 @@
     {
         "comp_description": "Masonry Chimney - unreinforced, non industrial, above roof 15 ft, replace with framing - Demand parameter shall be defined as the first floor peak floor acceleration. Unreinforced masonry chimney as a component of wood frame buildings. Includes firebox and chimney, excludes exterior veneer or ornamentation. May include chimneys where the quality of reinforcing is unknown. For multiple story buildings enter the chimney fragility once at the first floor, do not specify this fragility at subsequent elevated floors.",
         "comp_detail": "Unreinforced - unbraced",
-        "component": "B.20.1.2.A",
         "id": "B3031.002c",
         "material": "Masonry",
         "p58_fragility": "B3031.002c",
@@ -911,7 +810,6 @@
     {
         "comp_description": "Masonry Parapet - unreinforced, unbraced - Unreinforced and unbraced masonry parapet as a component of a masonry building. Parapet height / width of approximately 3. Costing based upon repair of 3ft tall x 10ft segment.",
         "comp_detail": "Unreinforced - unbraced",
-        "component": "B.20.1.2.A",
         "id": "B3041.001",
         "material": "Masonry",
         "p58_fragility": "B3041.001",
@@ -920,7 +818,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum with metal studs, Full Height, Fixed Below, Fixed Above - Quantity is based upon 13'x100' Panels. Quantity of wall damaged varies by damage state.",
         "comp_detail": "Full height - Fixed",
-        "component": "C.10.1.1.A",
         "id": "C1011.001a",
         "material": "Cold-formed steel stud with gypsum sheathing",
         "p58_fragility": "C1011.001a",
@@ -929,7 +826,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum with metal studs, Partial Height, Fixed Below, Lateral Braced Above - Quantity is based upon 13'x100' Panels. Quantity of wall damaged varies by damage state.",
         "comp_detail": "Partial height - laterally braced",
-        "component": "C.10.1.1.A",
         "id": "C1011.001b",
         "material": "Cold-formed steel stud with gypsum sheathing",
         "p58_fragility": "C1011.001b",
@@ -938,7 +834,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum with metal studs, Full Height, Fixed Below, Slip Track Above with returns - Quantity is based upon 13'x100' Panels. Quantity of wall damaged varies by damage state.",
         "comp_detail": "Full height - Slip track",
-        "component": "C.10.1.1.A",
         "id": "C1011.001c",
         "material": "Cold-formed steel stud with gypsum sheathing",
         "p58_fragility": "C1011.001c",
@@ -947,7 +842,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum with metal studs, Full Height, Fixed Below, Slip Track Above w/o returns (friction connections) - Quantity is based upon 13'x100' Panels. Quantity of wall damaged varies by damage state.",
         "comp_detail": "Full height - Slip track",
-        "component": "C.10.1.1.A",
         "id": "C1011.001d",
         "material": "Cold-formed steel stud with gypsum sheathing",
         "p58_fragility": "C1011.001d",
@@ -956,7 +850,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum with wood studs, Full Height, Fixed Below, Fixed Above - Quantity is based upon 13'x100' Panels. Quantity of wall damaged varies by damage state.",
         "comp_detail": "Full height - Fixed",
-        "component": "C.10.1.1.B",
         "id": "C1011.011a",
         "material": "Wood stud with gypsum sheathing",
         "p58_fragility": "C1011.011a",
@@ -965,7 +858,6 @@
     {
         "comp_description": "Prefabricated steel stair with steel treads and landings with seismic joints that accommodate drift. - Flexible stair with seismic interstory slip joint. Steel prefab stringers, steel or concrete filled pan treads.",
         "comp_detail": "Seismic joints",
-        "component": "C.20.1.1.A",
         "id": "C2011.001a",
         "material": "Steel",
         "p58_fragility": "C2011.001a",
@@ -974,7 +866,6 @@
     {
         "comp_description": "Prefabricated steel stair with steel treads and landings with no seismic joint. - Flexible stair without seismic interstory slip joint. Steel prefab stringers, steel or concrete filled pan treads.",
         "comp_detail": "Fixed",
-        "component": "C.20.1.1.A",
         "id": "C2011.001b",
         "material": "Steel",
         "p58_fragility": "C2011.001b",
@@ -983,7 +874,6 @@
     {
         "comp_description": "Non-monolithic precast concrete stair assembly with concrete stringers and treads with seismic joints that accommodate drift. - Rigid stair with seismic interstory drift joint. Precast concrete stair.",
         "comp_detail": "Seismic joints",
-        "component": "C.20.1.1.B",
         "id": "C2011.011a",
         "material": "Reinforced concrete",
         "p58_fragility": "C2011.011a",
@@ -992,7 +882,6 @@
     {
         "comp_description": "Non-monolithic precast concrete stair assembly with concrete stringers and treads with no seismic joint. - Rigid stair without seismic interstory drift joint. Precast concrete stair.",
         "comp_detail": "Fixed",
-        "component": "C.20.1.1.B",
         "id": "C2011.011b",
         "material": "Reinforced concrete",
         "p58_fragility": "C2011.011b",
@@ -1001,7 +890,6 @@
     {
         "comp_description": "Monolithic cast-in-place and precast concrete stairs with seismic joints that accommodate drift - replace in kind if replacement is required. - Cast in place concrete stair, with seismic interstory drift joint",
         "comp_detail": "Seismic joints",
-        "component": "C.20.1.1.C",
         "id": "C2011.021a",
         "material": "Reinforced concrete",
         "p58_fragility": "C2011.021a",
@@ -1010,7 +898,6 @@
     {
         "comp_description": "Monolithic cast-in-place and precast concrete stairs with no seismic joints - replace in kind if replacement is required. - Cast in place concrete stair, no seismic interstory drift joint",
         "comp_detail": "Fixed",
-        "component": "C.20.1.1.C",
         "id": "C2011.021b",
         "material": "Reinforced concrete",
         "p58_fragility": "C2011.021b",
@@ -1019,7 +906,6 @@
     {
         "comp_description": "Monolithic cast-in-place and precast concrete stairs with seismic joints that accommodate drift - replace with prefabricated steel stair if replacement is required. - Cast in place concrete stair, with seismic interstory drift joint",
         "comp_detail": "Seismic joints",
-        "component": "C.20.1.1.C",
         "id": "C2011.021c",
         "material": "Reinforced concrete",
         "p58_fragility": "C2011.021c",
@@ -1028,7 +914,6 @@
     {
         "comp_description": "Monolithic cast-in-place and precast concrete stairs with no seismic joints - replace with prefabricated steel stair if replacement is required. - Cast in place concrete stair, no seismic interstory drift joint",
         "comp_detail": "Fixed",
-        "component": "C.20.1.1.C",
         "id": "C2011.021d",
         "material": "Reinforced concrete",
         "p58_fragility": "C2011.021d",
@@ -1037,7 +922,6 @@
     {
         "comp_description": "Hybrid stair assembly with steel stringers and concrete treads and landings with seismic joints that accommodate drift. - Stair consists of steel stringers with precast treads rigidly linked to stringer",
         "comp_detail": "Seismic joints",
-        "component": "C.20.1.1.D",
         "id": "C2011.031a",
         "material": "Steel - Hybrid",
         "p58_fragility": "C2011.031a",
@@ -1046,7 +930,6 @@
     {
         "comp_description": "Hybrid stair assembly with steel stringers and concrete treads and landings with no seismic joints. - Stair consists of steel stringers with precast treads rigidly linked to stringer",
         "comp_detail": "Fixed",
-        "component": "C.20.1.1.D",
         "id": "C2011.031b",
         "material": "Steel - Hybrid",
         "p58_fragility": "C2011.031b",
@@ -1055,7 +938,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Wallpaper, Full Height, Fixed Below, Fixed Above - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - fixed",
-        "component": "C.30.1.2.A",
         "id": "C3011.001a",
         "material": "Wall paper",
         "p58_fragility": "C3011.001a",
@@ -1064,7 +946,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Wallpaper, Partial Height, Fixed Below, Lateral Braced Above - Costing based upon 9'x100' Panels",
         "comp_detail": "Partial height - laterally braced",
-        "component": "C.30.1.2.A",
         "id": "C3011.001b",
         "material": "Wall paper",
         "p58_fragility": "C3011.001b",
@@ -1073,7 +954,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Wallpaper, Full Height, Fixed Below, Slip Track Above w/ returns (friction connection) - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - slip track",
-        "component": "C.30.1.2.A",
         "id": "C3011.001c",
         "material": "Wall paper",
         "p58_fragility": "C3011.001c",
@@ -1082,7 +962,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Wallpaper, Full Height, Fixed Below, Slip Track Above w/o returns (friction connection) - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - slip track",
-        "component": "C.30.1.2.A",
         "id": "C3011.001d",
         "material": "Wall paper",
         "p58_fragility": "C3011.001d",
@@ -1091,7 +970,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Ceramic Tile, Full Height, Fixed Below, Fixed Above - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - fixed",
-        "component": "C.30.1.2.A",
         "id": "C3011.002a",
         "material": "Ceramic tile",
         "p58_fragility": "C3011.002a",
@@ -1100,7 +978,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Ceramic Tile, Partial Height, Fixed Below, Lateral Braced Above - Costing based upon 9'x100' Panels",
         "comp_detail": "Partial height - laterally braced",
-        "component": "C.30.1.2.A",
         "id": "C3011.002b",
         "material": "Ceramic tile",
         "p58_fragility": "C3011.002b",
@@ -1109,7 +986,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Ceramic Tile, Full Height, Fixed Below, Slip Track Above w/ returns (friction connection) - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - slip track",
-        "component": "C.30.1.2.A",
         "id": "C3011.002c",
         "material": "Ceramic tile",
         "p58_fragility": "C3011.002c",
@@ -1118,7 +994,6 @@
     {
         "comp_description": "Wall Partition, Type: Gypsum + Ceramic Tile, Full Height, Fixed Below, Slip Track Above w/o returns (friction connection) - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - slip track",
-        "component": "C.30.1.2.A",
         "id": "C3011.002d",
         "material": "Ceramic tile",
         "p58_fragility": "C3011.002d",
@@ -1127,7 +1002,6 @@
     {
         "comp_description": "Wall Partition, Type: High End Marble or Wood Panel, Full Height, Fixed Below, Fixed Above - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - fixed",
-        "component": "C.30.1.2.A",
         "id": "C3011.003a",
         "material": "Marble or wood panel",
         "p58_fragility": "C3011.003a",
@@ -1136,7 +1010,6 @@
     {
         "comp_description": "Wall Partition, Type: High End Marble or Wood Panel, Partial Height, Fixed Below, Lateral Braced Above - Costing based upon 9'x100' Panels",
         "comp_detail": "Partial height - laterally braced",
-        "component": "C.30.1.2.A",
         "id": "C3011.003b",
         "material": "Marble or wood panel",
         "p58_fragility": "C3011.003b",
@@ -1145,7 +1018,6 @@
     {
         "comp_description": "Wall Partition, Type: High End Marble or Wood Panel, Full Height, Fixed Below, Slip Track Above w/ returns (friction connection) - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - slip track",
-        "component": "C.30.1.2.A",
         "id": "C3011.003c",
         "material": "Marble or wood panel",
         "p58_fragility": "C3011.003c",
@@ -1154,7 +1026,6 @@
     {
         "comp_description": "Wall Partition, Type: High End Marble or Wood Panel, Full Height, Fixed Below, Slip Track Above w/o returns (friction connection) - Costing based upon 9'x100' Panels",
         "comp_detail": "Full height - slip track",
-        "component": "C.30.1.2.A",
         "id": "C3011.003d",
         "material": "Marble or wood panel",
         "p58_fragility": "C3011.003d",
@@ -1163,7 +1034,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Office - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be carpet or vinyl. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001a",
         "material": "",
         "p58_fragility": "C3021.001a",
@@ -1172,7 +1042,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Office - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be carpet or vinyl. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001b",
         "material": "",
         "p58_fragility": "C3021.001b",
@@ -1181,7 +1050,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Laboratory - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be sheet vinyl. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001c",
         "material": "",
         "p58_fragility": "C3021.001c",
@@ -1190,7 +1058,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Laboratory - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be sheet vinyl. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001d",
         "material": "",
         "p58_fragility": "C3021.001d",
@@ -1199,7 +1066,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Hospital - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be sheet vinyl. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001e",
         "material": "",
         "p58_fragility": "C3021.001e",
@@ -1208,7 +1074,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Hospital - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be sheet vinyl. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001f",
         "material": "",
         "p58_fragility": "C3021.001f",
@@ -1217,7 +1082,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - School - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be vinyl composition tile. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001g",
         "material": "",
         "p58_fragility": "C3021.001g",
@@ -1226,7 +1090,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - School - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be vinyl composition tile. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001h",
         "material": "",
         "p58_fragility": "C3021.001h",
@@ -1235,7 +1098,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Apartments - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be carpet. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001i",
         "material": "",
         "p58_fragility": "C3021.001i",
@@ -1244,7 +1106,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Apartments - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be carpet. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001j",
         "material": "",
         "p58_fragility": "C3021.001j",
@@ -1253,7 +1114,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Retail - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be vinyl composition tile. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001k",
         "material": "",
         "p58_fragility": "C3021.001k",
@@ -1262,7 +1122,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Retail - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be vinyl composition tile. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001l",
         "material": "",
         "p58_fragility": "C3021.001l",
@@ -1271,7 +1130,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Warehouse - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be sealed concrete. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001m",
         "material": "",
         "p58_fragility": "C3021.001m",
@@ -1280,7 +1138,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Warehouse - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be sealed concrete. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001n",
         "material": "",
         "p58_fragility": "C3021.001n",
@@ -1289,7 +1146,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Hospitality - Dry - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be carpet. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001o",
         "material": "",
         "p58_fragility": "C3021.001o",
@@ -1298,7 +1154,6 @@
     {
         "comp_description": "Generic Floor Covering - Flooding of floor caused by failure of pipe - Hospitality - Humid - The user needs to review the fragilities of all piping modeled in the ceiling of the floor and input the peak floor acceleration value for the pipe with the lowest median peak floor acceleration value, along with the associated total dispersion (beta). Flooring type assumed to be carpet. Available costs are per one square foot of floor area.",
         "comp_detail": "",
-        "component": "C.30.2.1.A",
         "id": "C3021.001p",
         "material": "",
         "p58_fragility": "C3021.001p",
@@ -1307,7 +1162,6 @@
     {
         "comp_description": "Raised Access Floor, non seismically rated. - Access floor unanchored or anchored with adhesive. Costing is based upon a xxx SF floor area.",
         "comp_detail": "Not seismically rated",
-        "component": "C.30.2.7.A",
         "id": "C3027.001",
         "material": "",
         "p58_fragility": "C3027.001",
@@ -1316,7 +1170,6 @@
     {
         "comp_description": "Raised Access Floor, seismically rated. - Access floor is designed to meet code requirements and mechanically anchored and braced as necessary to resist anchor loads. Equipment is anchored to floor systems and heavier equipment is anchored directly to the structural floor. Costing is based upon a xxx SF floor area.",
         "comp_detail": "Seismically rated",
-        "component": "C.30.2.7.A",
         "id": "C3027.002",
         "material": "",
         "p58_fragility": "C3027.002",
@@ -1325,7 +1178,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC A,B,C, Area (A): A < 250, Vert support only - Costing for each 250 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wires only. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC A/B/C",
-        "component": "C.30.3.2.A",
         "id": "C3032.001a",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.001a",
@@ -1334,7 +1186,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC A,B,C, Area (A): 250 < A < 1000, Vert support only - Costing for each 600 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wires only. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC A/B/C",
-        "component": "C.30.3.2.A",
         "id": "C3032.001b",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.001b",
@@ -1343,7 +1194,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC A,B,C, Area (A): 1000 < A < 2500, Vert support only - Costing for each 1800 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wires only. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC A/B/C",
-        "component": "C.30.3.2.A",
         "id": "C3032.001c",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.001c",
@@ -1352,7 +1202,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC A,B,C, Area (A): A > 2500, Vert support only - Costing for each 2500 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wires only. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC A/B/C",
-        "component": "C.30.3.2.A",
         "id": "C3032.001d",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.001d",
@@ -1361,7 +1210,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E (Ip=1.0), Area (A): A < 250, Vert & Lat support - Costing for each 250 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E",
-        "component": "C.30.3.2.A",
         "id": "C3032.003a",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.003a",
@@ -1370,7 +1218,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E (Ip=1.0), Area (A): 250 < A < 1000, Vert & Lat support - Costing for each 600 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E",
-        "component": "C.30.3.2.A",
         "id": "C3032.003b",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.003b",
@@ -1379,7 +1226,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E (Ip=1.0), Area (A): 1000 < A < 2500, Vert & Lat support - Costing for each 1800 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E",
-        "component": "C.30.3.2.A",
         "id": "C3032.003c",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.003c",
@@ -1388,7 +1234,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E (Ip=1.0), Area (A): A > 2500, Vert & Lat support - Costing for each 2500 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E",
-        "component": "C.30.3.2.A",
         "id": "C3032.003d",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.003d",
@@ -1397,7 +1242,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E,F (Ip=1.5), Area (A): A < 250, Vert & Lat support - Costing for each 250 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E/F (Ip = 1.5)",
-        "component": "C.30.3.2.A",
         "id": "C3032.004a",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.004a",
@@ -1406,7 +1250,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E,F (Ip=1.5), Area (A): 250 < A < 1000, Vert & Lat support - Costing for each 600 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E/F (Ip = 1.5)",
-        "component": "C.30.3.2.A",
         "id": "C3032.004b",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.004b",
@@ -1415,7 +1258,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E,F (Ip=1.5), Area (A): 1000 < A < 2500, Vert & Lat support - Costing for each 1800 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E/F (Ip = 1.5)",
-        "component": "C.30.3.2.A",
         "id": "C3032.004c",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.004c",
@@ -1424,7 +1266,6 @@
     {
         "comp_description": "Suspended Ceiling, SDC D,E,F (Ip=1.5), Area (A): A > 2500, Vert & Lat support - Costing for each 2500 SF Unit, Suspended Lay-in Acoustic Tile Ceiling, Support: Vertical hanging wire, diagonal wires, and compression posts, 2 inch wide ledger support angles at wall and oversize holes around tile openings. Includes lighting fixtures in suspended ceiling.",
         "comp_detail": "SDC D/E/F (Ip = 1.5)",
-        "component": "C.30.3.2.A",
         "id": "C3032.004d",
         "material": "Lay-in acoustic tile ceiling",
         "p58_fragility": "C3032.004d",
@@ -1433,7 +1274,6 @@
     {
         "comp_description": "Independent Pendant Lighting - non seismic - Horizontal light fixtures 4 to 16 ft long suspended 12 to 24 inches from ceiling. No seismic design or bracing. Hung from ceiling above by two or more rods or cables.",
         "comp_detail": "Not seismically rated",
-        "component": "D.50.2.2.A",
         "id": "C3034.001",
         "material": "",
         "p58_fragility": "C3034.001",
@@ -1442,7 +1282,6 @@
     {
         "comp_description": "Independent Pendant Lighting - seismically rated - Horizontal light fixtures 4 to 16 ft long suspended 12 to 24 inches from ceiling. Hung from ceiling above by two or more rods or cables. Fixture and rods or cables are either designed for seismic movements or are laterally braced to prevent sway.",
         "comp_detail": "Seismically rated",
-        "component": "D.50.2.2.A",
         "id": "C3034.002",
         "material": "",
         "p58_fragility": "C3034.002",
@@ -1451,7 +1290,6 @@
     {
         "comp_description": "Traction Elevator. Applies to most California Installations 1976 or later, most western states installations 1982 or later and most other U.S installations 1998 or later. - Costing per elevator. Elevator demand parameter shall be defined as the peak floor acceleration at the first floor. The elevator fragility for a multiple story building should only be entered once on the first floor.",
         "comp_detail": "Traction elevator - post 1976",
-        "component": "D.10.1.1.A",
         "id": "D1014.011",
         "material": "",
         "p58_fragility": "D1014.011",
@@ -1460,7 +1298,6 @@
     {
         "comp_description": "Traction Elevator. Applies to most California Installations prior to 1976, most western states installations prior to 1982 and most other U.S installations prior to 1998. - Costing per elevator. Elevator demand parameter shall be defined as the peak floor acceleration at the first floor. The elevator fragility for a multiple story building should only be entered once on the first floor.",
         "comp_detail": "Traction elevator - pre 1976",
-        "component": "D.10.1.1.A",
         "id": "D1014.012",
         "material": "",
         "p58_fragility": "D1014.012",
@@ -1469,7 +1306,6 @@
     {
         "comp_description": "Hydraulic Elevator. Applies to most California Installations 1976 or later, most western states installations postdating 1982 and most U.S installations postdating 1998. - Costing per elevator. Elevator demand parameter shall be defined as the peak floor acceleration at the first floor. The elevator fragility for a multiple story building should only be entered once on the first floor.",
         "comp_detail": "Hydraulic elevator - post 1976",
-        "component": "D.10.1.1.B",
         "id": "D1014.021",
         "material": "",
         "p58_fragility": "D1014.021",
@@ -1478,7 +1314,6 @@
     {
         "comp_description": "Hydraulic Elevator. Applies to most California Installations prior to 1976, most western states installations prior to 1982 and most U.S installations prior to 1998. - Costing per elevator. Elevator demand parameter shall be defined as the peak floor acceleration at the first floor. The elevator fragility for a multiple story building should only be entered once on the first floor.",
         "comp_detail": "Hydraulic elevator - pre 1976",
-        "component": "D.10.1.1.B",
         "id": "D1014.022",
         "material": "",
         "p58_fragility": "D1014.022",
@@ -1487,7 +1322,6 @@
     {
         "comp_description": "Steam Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.3.A",
         "id": "D2061.023a",
         "material": "Welded steel piping",
         "p58_fragility": "D2061.023a",
@@ -1496,7 +1330,6 @@
     {
         "comp_description": "Steam Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.3.A",
         "id": "D2061.023b",
         "material": "Bracing",
         "p58_fragility": "D2061.023b",
@@ -1505,7 +1338,6 @@
     {
         "comp_description": "Steam Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.3.A",
         "id": "D2061.024a",
         "material": "Welded steel piping",
         "p58_fragility": "D2061.024a",
@@ -1514,7 +1346,6 @@
     {
         "comp_description": "Steam Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F (OSHPD or sim), BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.3.A",
         "id": "D2061.024b",
         "material": "Bracing",
         "p58_fragility": "D2061.024b",
@@ -1523,7 +1354,6 @@
     {
         "comp_description": "Chiller - Capacity: < 100 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.A",
         "id": "D3031.011a",
         "material": "",
         "p58_fragility": "D3031.011a",
@@ -1532,7 +1362,6 @@
     {
         "comp_description": "Chiller - Capacity: 100 to <350 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.A",
         "id": "D3031.011b",
         "material": "",
         "p58_fragility": "D3031.011b",
@@ -1541,7 +1370,6 @@
     {
         "comp_description": "Chiller - Capacity: 350 to <750 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.A",
         "id": "D3031.011c",
         "material": "",
         "p58_fragility": "D3031.011c",
@@ -1550,7 +1378,6 @@
     {
         "comp_description": "Chiller - Capacity: 750 to <1000 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.A",
         "id": "D3031.011d",
         "material": "",
         "p58_fragility": "D3031.011d",
@@ -1559,7 +1386,6 @@
     {
         "comp_description": "Chiller - Capacity: < 100 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012a",
         "material": "",
         "p58_fragility": "D3031.012a",
@@ -1568,7 +1394,6 @@
     {
         "comp_description": "Chiller - Capacity: < 100 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012b",
         "material": "",
         "p58_fragility": "D3031.012b",
@@ -1577,7 +1402,6 @@
     {
         "comp_description": "Chiller - Capacity: < 100 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012c",
         "material": "",
         "p58_fragility": "D3031.012c",
@@ -1586,7 +1410,6 @@
     {
         "comp_description": "Chiller - Capacity: 100 to <350 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012d",
         "material": "",
         "p58_fragility": "D3031.012d",
@@ -1595,7 +1418,6 @@
     {
         "comp_description": "Chiller - Capacity: 100 to <350 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012e",
         "material": "",
         "p58_fragility": "D3031.012e",
@@ -1604,7 +1426,6 @@
     {
         "comp_description": "Chiller - Capacity: 100 to <350 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012f",
         "material": "",
         "p58_fragility": "D3031.012f",
@@ -1613,7 +1434,6 @@
     {
         "comp_description": "Chiller - Capacity: 350 to <750 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012g",
         "material": "",
         "p58_fragility": "D3031.012g",
@@ -1622,7 +1442,6 @@
     {
         "comp_description": "Chiller - Capacity: 350 to <750 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012h",
         "material": "",
         "p58_fragility": "D3031.012h",
@@ -1631,7 +1450,6 @@
     {
         "comp_description": "Chiller - Capacity: 350 to <750 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012i",
         "material": "",
         "p58_fragility": "D3031.012i",
@@ -1640,7 +1458,6 @@
     {
         "comp_description": "Chiller - Capacity: 750 to <1000 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012j",
         "material": "",
         "p58_fragility": "D3031.012j",
@@ -1649,7 +1466,6 @@
     {
         "comp_description": "Chiller - Capacity: 750 to <1000 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012k",
         "material": "",
         "p58_fragility": "D3031.012k",
@@ -1658,7 +1474,6 @@
     {
         "comp_description": "Chiller - Capacity: 750 to <1000 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.A",
         "id": "D3031.012l",
         "material": "",
         "p58_fragility": "D3031.012l",
@@ -1667,7 +1482,6 @@
     {
         "comp_description": "Chiller - Capacity: < 100 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013a",
         "material": "",
         "p58_fragility": "D3031.013a",
@@ -1676,7 +1490,6 @@
     {
         "comp_description": "Chiller - Capacity: < 100 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013b",
         "material": "",
         "p58_fragility": "D3031.013b",
@@ -1685,7 +1498,6 @@
     {
         "comp_description": "Chiller - Capacity: < 100 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013c",
         "material": "",
         "p58_fragility": "D3031.013c",
@@ -1694,7 +1506,6 @@
     {
         "comp_description": "Chiller - Capacity: 100 to <350 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013d",
         "material": "",
         "p58_fragility": "D3031.013d",
@@ -1703,7 +1514,6 @@
     {
         "comp_description": "Chiller - Capacity: 100 to <350 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013e",
         "material": "",
         "p58_fragility": "D3031.013e",
@@ -1712,7 +1522,6 @@
     {
         "comp_description": "Chiller - Capacity: 100 to <350 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013f",
         "material": "",
         "p58_fragility": "D3031.013f",
@@ -1721,7 +1530,6 @@
     {
         "comp_description": "Chiller - Capacity: 350 to <750 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013g",
         "material": "",
         "p58_fragility": "D3031.013g",
@@ -1730,7 +1538,6 @@
     {
         "comp_description": "Chiller - Capacity: 350 to <750 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013h",
         "material": "",
         "p58_fragility": "D3031.013h",
@@ -1739,7 +1546,6 @@
     {
         "comp_description": "Chiller - Capacity: 350 to <750 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013i",
         "material": "",
         "p58_fragility": "D3031.013i",
@@ -1748,7 +1554,6 @@
     {
         "comp_description": "Chiller - Capacity: 750 to <1000 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013j",
         "material": "",
         "p58_fragility": "D3031.013j",
@@ -1757,7 +1562,6 @@
     {
         "comp_description": "Chiller - Capacity: 750 to <1000 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013k",
         "material": "",
         "p58_fragility": "D3031.013k",
@@ -1766,7 +1570,6 @@
     {
         "comp_description": "Chiller - Capacity: 750 to <1000 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.A",
         "id": "D3031.013l",
         "material": "",
         "p58_fragility": "D3031.013l",
@@ -1775,7 +1578,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: < 100 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.B",
         "id": "D3031.021a",
         "material": "",
         "p58_fragility": "D3031.021a",
@@ -1784,7 +1586,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 100 to <350 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.B",
         "id": "D3031.021b",
         "material": "",
         "p58_fragility": "D3031.021b",
@@ -1793,7 +1594,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 350 to <750 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.B",
         "id": "D3031.021c",
         "material": "",
         "p58_fragility": "D3031.021c",
@@ -1802,7 +1602,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 750 to <1000 Ton - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.1.B",
         "id": "D3031.021d",
         "material": "",
         "p58_fragility": "D3031.021d",
@@ -1811,7 +1610,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: < 100 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022a",
         "material": "",
         "p58_fragility": "D3031.022a",
@@ -1820,7 +1618,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: < 100 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022b",
         "material": "",
         "p58_fragility": "D3031.022b",
@@ -1829,7 +1626,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: < 100 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022c",
         "material": "",
         "p58_fragility": "D3031.022c",
@@ -1838,7 +1634,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 100 to <350 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022d",
         "material": "",
         "p58_fragility": "D3031.022d",
@@ -1847,7 +1642,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 100 to <350 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022e",
         "material": "",
         "p58_fragility": "D3031.022e",
@@ -1856,7 +1650,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 100 to <350 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022f",
         "material": "",
         "p58_fragility": "D3031.022f",
@@ -1865,7 +1658,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 350 to <750 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022g",
         "material": "",
         "p58_fragility": "D3031.022g",
@@ -1874,7 +1666,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 350 to <750 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022h",
         "material": "",
         "p58_fragility": "D3031.022h",
@@ -1883,7 +1674,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 350 to <750 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022i",
         "material": "",
         "p58_fragility": "D3031.022i",
@@ -1892,7 +1682,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 750 to <1000 Ton - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022j",
         "material": "",
         "p58_fragility": "D3031.022j",
@@ -1901,7 +1690,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 750 to <1000 Ton - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022k",
         "material": "",
         "p58_fragility": "D3031.022k",
@@ -1910,7 +1698,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 750 to <1000 Ton - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.1.B",
         "id": "D3031.022l",
         "material": "",
         "p58_fragility": "D3031.022l",
@@ -1919,7 +1706,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: < 100 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023a",
         "material": "",
         "p58_fragility": "D3031.023a",
@@ -1928,7 +1714,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: < 100 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023b",
         "material": "",
         "p58_fragility": "D3031.023b",
@@ -1937,7 +1722,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: < 100 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 75 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023c",
         "material": "",
         "p58_fragility": "D3031.023c",
@@ -1946,7 +1730,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 100 to <350 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023d",
         "material": "",
         "p58_fragility": "D3031.023d",
@@ -1955,7 +1738,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 100 to <350 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023e",
         "material": "",
         "p58_fragility": "D3031.023e",
@@ -1964,7 +1746,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 100 to <350 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 250 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023f",
         "material": "",
         "p58_fragility": "D3031.023f",
@@ -1973,7 +1754,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 350 to <750 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023g",
         "material": "",
         "p58_fragility": "D3031.023g",
@@ -1982,7 +1762,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 350 to <750 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023h",
         "material": "",
         "p58_fragility": "D3031.023h",
@@ -1991,7 +1770,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 350 to <750 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 500 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023i",
         "material": "",
         "p58_fragility": "D3031.023i",
@@ -2000,7 +1778,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 750 to <1000 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023j",
         "material": "",
         "p58_fragility": "D3031.023j",
@@ -2009,7 +1786,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 750 to <1000 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023k",
         "material": "",
         "p58_fragility": "D3031.023k",
@@ -2018,7 +1794,6 @@
     {
         "comp_description": "Cooling Tower - Capacity: 750 to <1000 Ton - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 850 Ton.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.1.B",
         "id": "D3031.023l",
         "material": "",
         "p58_fragility": "D3031.023l",
@@ -2027,7 +1802,6 @@
     {
         "comp_description": "Compressor - Capacity: Small non medical air supply - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.2.A",
         "id": "D3032.011a",
         "material": "",
         "p58_fragility": "D3032.011a",
@@ -2036,7 +1810,6 @@
     {
         "comp_description": "Compressor - Capacity: Large non medical air supply - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.2.A",
         "id": "D3032.011b",
         "material": "",
         "p58_fragility": "D3032.011b",
@@ -2045,7 +1818,6 @@
     {
         "comp_description": "Compressor - Capacity: Small medical quality air supply - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.2.A",
         "id": "D3032.011c",
         "material": "",
         "p58_fragility": "D3032.011c",
@@ -2054,7 +1826,6 @@
     {
         "comp_description": "Compressor - Capacity: Large medical quality air supply - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.30.3.2.A",
         "id": "D3032.011d",
         "material": "",
         "p58_fragility": "D3032.011d",
@@ -2063,7 +1834,6 @@
     {
         "comp_description": "Compressor - Capacity: Small non medical air supply - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012a",
         "material": "",
         "p58_fragility": "D3032.012a",
@@ -2072,7 +1842,6 @@
     {
         "comp_description": "Compressor - Capacity: Small non medical air supply - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012b",
         "material": "",
         "p58_fragility": "D3032.012b",
@@ -2081,7 +1850,6 @@
     {
         "comp_description": "Compressor - Capacity: Small non medical air supply - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012c",
         "material": "",
         "p58_fragility": "D3032.012c",
@@ -2090,7 +1858,6 @@
     {
         "comp_description": "Compressor - Capacity: Large non medical air supply - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012d",
         "material": "",
         "p58_fragility": "D3032.012d",
@@ -2099,7 +1866,6 @@
     {
         "comp_description": "Compressor - Capacity: Large non medical air supply - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012e",
         "material": "",
         "p58_fragility": "D3032.012e",
@@ -2108,7 +1874,6 @@
     {
         "comp_description": "Compressor - Capacity: Large non medical air supply - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012f",
         "material": "",
         "p58_fragility": "D3032.012f",
@@ -2117,7 +1882,6 @@
     {
         "comp_description": "Compressor - Capacity: Small medical quality air supply - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012g",
         "material": "",
         "p58_fragility": "D3032.012g",
@@ -2126,7 +1890,6 @@
     {
         "comp_description": "Compressor - Capacity: Small medical quality air supply - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012h",
         "material": "",
         "p58_fragility": "D3032.012h",
@@ -2135,7 +1898,6 @@
     {
         "comp_description": "Compressor - Capacity: Small medical quality air supply - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012i",
         "material": "",
         "p58_fragility": "D3032.012i",
@@ -2144,7 +1906,6 @@
     {
         "comp_description": "Compressor - Capacity: Large medical quality air supply - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012j",
         "material": "",
         "p58_fragility": "D3032.012j",
@@ -2153,7 +1914,6 @@
     {
         "comp_description": "Compressor - Capacity: Large medical quality air supply - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012k",
         "material": "",
         "p58_fragility": "D3032.012k",
@@ -2162,7 +1922,6 @@
     {
         "comp_description": "Compressor - Capacity: Large medical quality air supply - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.3.2.A",
         "id": "D3032.012l",
         "material": "",
         "p58_fragility": "D3032.012l",
@@ -2171,7 +1930,6 @@
     {
         "comp_description": "Compressor - Capacity: Small non medical air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013a",
         "material": "",
         "p58_fragility": "D3032.013a",
@@ -2180,7 +1938,6 @@
     {
         "comp_description": "Compressor - Capacity: Small non medical air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013b",
         "material": "",
         "p58_fragility": "D3032.013b",
@@ -2189,7 +1946,6 @@
     {
         "comp_description": "Compressor - Capacity: Small non medical air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013c",
         "material": "",
         "p58_fragility": "D3032.013c",
@@ -2198,7 +1954,6 @@
     {
         "comp_description": "Compressor - Capacity: Large non medical air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013d",
         "material": "",
         "p58_fragility": "D3032.013d",
@@ -2207,7 +1962,6 @@
     {
         "comp_description": "Compressor - Capacity: Large non medical air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013e",
         "material": "",
         "p58_fragility": "D3032.013e",
@@ -2216,7 +1970,6 @@
     {
         "comp_description": "Compressor - Capacity: Large non medical air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013f",
         "material": "",
         "p58_fragility": "D3032.013f",
@@ -2225,7 +1978,6 @@
     {
         "comp_description": "Compressor - Capacity: Small medical quality air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013g",
         "material": "",
         "p58_fragility": "D3032.013g",
@@ -2234,7 +1986,6 @@
     {
         "comp_description": "Compressor - Capacity: Small medical quality air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013h",
         "material": "",
         "p58_fragility": "D3032.013h",
@@ -2243,7 +1994,6 @@
     {
         "comp_description": "Compressor - Capacity: Small medical quality air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013i",
         "material": "",
         "p58_fragility": "D3032.013i",
@@ -2252,7 +2002,6 @@
     {
         "comp_description": "Compressor - Capacity: Large medical quality air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013j",
         "material": "",
         "p58_fragility": "D3032.013j",
@@ -2261,7 +2010,6 @@
     {
         "comp_description": "Compressor - Capacity: Large medical quality air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013k",
         "material": "",
         "p58_fragility": "D3032.013k",
@@ -2270,7 +2018,6 @@
     {
         "comp_description": "Compressor - Capacity: Large medical quality air supply - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.3.2.A",
         "id": "D3032.013l",
         "material": "",
         "p58_fragility": "D3032.013l",
@@ -2279,7 +2026,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported and vibration isolators, SDC A or B - Costing per 10 units",
         "comp_detail": "SDC A/B - independently supported and vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.001a",
         "material": "",
         "p58_fragility": "D3041.001a",
@@ -2288,7 +2034,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported and vibration isolators, SDC C - Costing per 10 units",
         "comp_detail": "SDC C - independently supported and vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.001b",
         "material": "",
         "p58_fragility": "D3041.001b",
@@ -2297,7 +2042,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported and vibration isolators, SDC D, E, F - Costing per 10 units",
         "comp_detail": "SDC D/E/F - independently supported and vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.001c",
         "material": "",
         "p58_fragility": "D3041.001c",
@@ -2306,7 +2050,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported and vibration isolators, SDC D, E, F (OSHPD or sim) - Costing per 10 units",
         "comp_detail": "SDC D/E/F hospital - independently supported and vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.001d",
         "material": "",
         "p58_fragility": "D3041.001d",
@@ -2315,7 +2058,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported but not on vibration isolators, SDC A or B - Costing per 10 units",
         "comp_detail": "SDC A/B - independently supported - no vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.002a",
         "material": "",
         "p58_fragility": "D3041.002a",
@@ -2324,7 +2066,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported but not on vibration isolators, SDC C - Costing per 10 units",
         "comp_detail": "SDC C - independently supported - no vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.002b",
         "material": "",
         "p58_fragility": "D3041.002b",
@@ -2333,7 +2074,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported but not on vibration isolators, SDC D, E, F - Costing per 10 units",
         "comp_detail": "SDC D/E/F - independently supported - no vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.002c",
         "material": "",
         "p58_fragility": "D3041.002c",
@@ -2342,7 +2082,6 @@
     {
         "comp_description": "HVAC Fan In Line Fan, Fan independently supported but not on vibration isolators, SDC D, E, F (OSHPD or sim) - Costing per 10 units",
         "comp_detail": "SDC D/E/F hospital - independently supported - no vibration isolators",
-        "component": "D.30.4.1.C",
         "id": "D3041.002d",
         "material": "",
         "p58_fragility": "D3041.002d",
@@ -2351,7 +2090,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting less than 6 sq. ft in cross sectional area, SDC A or B - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.1.A",
         "id": "D3041.011a",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.011a",
@@ -2360,7 +2098,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting less than 6 sq. ft in cross sectional area, SDC C - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC C",
-        "component": "D.30.4.1.A",
         "id": "D3041.011b",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.011b",
@@ -2369,7 +2106,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting less than 6 sq. ft in cross sectional area, SDC D, E, or F - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.1.A",
         "id": "D3041.011c",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.011c",
@@ -2378,7 +2114,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting less than 6 sq. ft in cross sectional area, SDC D, E, or F (OSHPD or sim) - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.1.A",
         "id": "D3041.011d",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.011d",
@@ -2387,7 +2122,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting - 6 sq. ft cross sectional area or greater, SDC A or B - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.1.A",
         "id": "D3041.012a",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.012a",
@@ -2396,7 +2130,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting - 6 sq. ft cross sectional area or greater, SDC C - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC C",
-        "component": "D.30.4.1.A",
         "id": "D3041.012b",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.012b",
@@ -2405,7 +2138,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting - 6 sq. ft cross sectional area or greater, SDC D, E, or F - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.1.A",
         "id": "D3041.012c",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.012c",
@@ -2414,7 +2146,6 @@
     {
         "comp_description": "HVAC Galvanized Sheet Metal Ducting - 6 sq. ft cross sectional area or greater, SDC D, E, or F (OSHPD or sim) - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.1.A",
         "id": "D3041.012d",
         "material": "Galvanized steel",
         "p58_fragility": "D3041.012d",
@@ -2423,7 +2154,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting less than 6 sq. ft in cross sectional area, SDC A or B - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.1.A",
         "id": "D3041.021a",
         "material": "Stainless steel",
         "p58_fragility": "D3041.021a",
@@ -2432,7 +2162,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting less than 6 sq. ft in cross sectional area, SDC C - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC C",
-        "component": "D.30.4.1.A",
         "id": "D3041.021b",
         "material": "Stainless steel",
         "p58_fragility": "D3041.021b",
@@ -2441,7 +2170,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting less than 6 sq. ft in cross sectional area, SDC D, E, or F - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.1.A",
         "id": "D3041.021c",
         "material": "Stainless steel",
         "p58_fragility": "D3041.021c",
@@ -2450,7 +2178,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting less than 6 sq. ft in cross sectional area, SDC D, E, or F (OSHPD or sim) - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.1.A",
         "id": "D3041.021d",
         "material": "Stainless steel",
         "p58_fragility": "D3041.021d",
@@ -2459,7 +2186,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting - 6 sq. ft cross sectional area or greater, SDC A or B - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.1.A",
         "id": "D3041.022a",
         "material": "Stainless steel",
         "p58_fragility": "D3041.022a",
@@ -2468,7 +2194,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting - 6 sq. ft cross sectional area or greater, SDC C - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC C",
-        "component": "D.30.4.1.A",
         "id": "D3041.022b",
         "material": "Stainless steel",
         "p58_fragility": "D3041.022b",
@@ -2477,7 +2202,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting - 6 sq. ft cross sectional area or greater, SDC D, E, or F - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.1.A",
         "id": "D3041.022c",
         "material": "Stainless steel",
         "p58_fragility": "D3041.022c",
@@ -2486,7 +2210,6 @@
     {
         "comp_description": "HVAC Stainless Steel Ducting - 6 sq. ft cross sectional area or greater, SDC D, E, or F (OSHPD or sim) - Costing based upon 1000 ft segments of duct",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.1.A",
         "id": "D3041.022d",
         "material": "Stainless steel",
         "p58_fragility": "D3041.022d",
@@ -2495,7 +2218,6 @@
     {
         "comp_description": "HVAC Drops / Diffusers in suspended ceilings - No independent safety wires, SDC A or B - Costing per 10 units, No independent safety wires",
         "comp_detail": "SDC A/B - in ceilings - No independent safety wire",
-        "component": "D.30.4.1.B",
         "id": "D3041.031a",
         "material": "",
         "p58_fragility": "D3041.031a",
@@ -2504,7 +2226,6 @@
     {
         "comp_description": "HVAC Drops / Diffusers in suspended ceilings - No independent safety wires, SDC C - Costing per 10 units, No independent safety wires",
         "comp_detail": "SDC C - in ceilings - No independent safety wire",
-        "component": "D.30.4.1.B",
         "id": "D3041.031b",
         "material": "",
         "p58_fragility": "D3041.031b",
@@ -2513,7 +2234,6 @@
     {
         "comp_description": "HVAC Drops / Diffusers without ceilings - supported by ducting only - No independent safety wires, SDC A or B - Costing per 10 units, unit supported by ducting only, no independent safety wires",
         "comp_detail": "SDC A/B - no ceilings - No independent safety wire",
-        "component": "D.30.4.1.B",
         "id": "D3041.032a",
         "material": "",
         "p58_fragility": "D3041.032a",
@@ -2522,7 +2242,6 @@
     {
         "comp_description": "HVAC Drops / Diffusers without ceilings - supported by ducting only - No independent safety wires, SDC C - Costing per 10 units, unit supported by ducting only, no independent safety wires",
         "comp_detail": "SDC C - no ceilings - No independent safety wire",
-        "component": "D.30.4.1.B",
         "id": "D3041.032b",
         "material": "",
         "p58_fragility": "D3041.032b",
@@ -2531,7 +2250,6 @@
     {
         "comp_description": "HVAC Drops / Diffusers without ceilings - supported by ducting only - No independent safety wires, SDC D, E, or F - Costing per 10 units, unit supported by ducting only, no independent safety wires",
         "comp_detail": "SDC D/E/F - no ceilings - No independent safety wire",
-        "component": "D.30.4.1.B",
         "id": "D3041.032c",
         "material": "",
         "p58_fragility": "D3041.032c",
@@ -2540,7 +2258,6 @@
     {
         "comp_description": "HVAC Drops / Diffusers without ceilings - supported by ducting only - No independent safety wires, SDC D, E, or F (OSHPD or sim) - Costing per 10 units, unit supported by ducting only, no independent safety wires",
         "comp_detail": "SDC D/E/F hospital - no ceilings - No independent safety wire",
-        "component": "D.30.4.1.B",
         "id": "D3041.032d",
         "material": "",
         "p58_fragility": "D3041.032d",
@@ -2549,7 +2266,6 @@
     {
         "comp_description": "Variable Air Volume (VAV) box with in-line coil, SDC A or B - Costing per 10 units",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.1.D",
         "id": "D3041.041a",
         "material": "",
         "p58_fragility": "D3041.041a",
@@ -2558,7 +2274,6 @@
     {
         "comp_description": "Variable Air Volume (VAV) box with in-line coil, SDC C - Costing per 10 units",
         "comp_detail": "SDC C",
-        "component": "D.30.4.1.D",
         "id": "D3041.041b",
         "material": "",
         "p58_fragility": "D3041.041b",
@@ -2567,7 +2282,6 @@
     {
         "comp_description": "HVAC Fan - Capacity: all - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.30.4.2.A",
         "id": "D3041.101a",
         "material": "",
         "p58_fragility": "D3041.101a",
@@ -2576,7 +2290,6 @@
     {
         "comp_description": "HVAC Fan - Capacity: all - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.4.2.A",
         "id": "D3041.102a",
         "material": "",
         "p58_fragility": "D3041.102a",
@@ -2585,7 +2298,6 @@
     {
         "comp_description": "HVAC Fan - Capacity: all - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.4.2.A",
         "id": "D3041.102b",
         "material": "",
         "p58_fragility": "D3041.102b",
@@ -2594,7 +2306,6 @@
     {
         "comp_description": "HVAC Fan - Capacity: all - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.30.4.2.A",
         "id": "D3041.102c",
         "material": "",
         "p58_fragility": "D3041.102c",
@@ -2603,7 +2314,6 @@
     {
         "comp_description": "HVAC Fan - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.4.2.A",
         "id": "D3041.103a",
         "material": "",
         "p58_fragility": "D3041.103a",
@@ -2612,7 +2322,6 @@
     {
         "comp_description": "HVAC Fan - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.4.2.A",
         "id": "D3041.103b",
         "material": "",
         "p58_fragility": "D3041.103b",
@@ -2621,7 +2330,6 @@
     {
         "comp_description": "HVAC Fan - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.4.2.A",
         "id": "D3041.103c",
         "material": "",
         "p58_fragility": "D3041.103c",
@@ -2630,7 +2338,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: <5000 CFM - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 4000 CFM.",
         "comp_detail": "Unanchored",
-        "component": "D.30.5.2.A",
         "id": "D3052.011a",
         "material": "",
         "p58_fragility": "D3052.011a",
@@ -2639,7 +2346,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 5000 to <10000 CFM - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 8000 CFM.",
         "comp_detail": "Unanchored",
-        "component": "D.30.5.2.A",
         "id": "D3052.011b",
         "material": "",
         "p58_fragility": "D3052.011b",
@@ -2648,7 +2354,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 10000 to <25000 CFM - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 20000 CFM.",
         "comp_detail": "Unanchored",
-        "component": "D.30.5.2.A",
         "id": "D3052.011c",
         "material": "",
         "p58_fragility": "D3052.011c",
@@ -2657,7 +2362,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 25000 to <40000 CFM - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 30000 CFM.",
         "comp_detail": "Unanchored",
-        "component": "D.30.5.2.A",
         "id": "D3052.011d",
         "material": "",
         "p58_fragility": "D3052.011d",
@@ -2666,7 +2370,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: <5000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 4000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013a",
         "material": "",
         "p58_fragility": "D3052.013a",
@@ -2675,7 +2378,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: <5000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 4000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013b",
         "material": "",
         "p58_fragility": "D3052.013b",
@@ -2684,7 +2386,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: <5000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 4000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013c",
         "material": "",
         "p58_fragility": "D3052.013c",
@@ -2693,7 +2394,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 5000 to <10000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 8000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013d",
         "material": "",
         "p58_fragility": "D3052.013d",
@@ -2702,7 +2402,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 5000 to <10000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 8000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013e",
         "material": "",
         "p58_fragility": "D3052.013e",
@@ -2711,7 +2410,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 5000 to <10000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 8000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013f",
         "material": "",
         "p58_fragility": "D3052.013f",
@@ -2720,7 +2418,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 10000 to <25000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 20000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013g",
         "material": "",
         "p58_fragility": "D3052.013g",
@@ -2729,7 +2426,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 10000 to <25000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 20000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013h",
         "material": "",
         "p58_fragility": "D3052.013h",
@@ -2738,7 +2434,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 10000 to <25000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 20000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013i",
         "material": "",
         "p58_fragility": "D3052.013i",
@@ -2747,7 +2442,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 25000 to <40000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 30000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013j",
         "material": "",
         "p58_fragility": "D3052.013j",
@@ -2756,7 +2450,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 25000 to <40000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 30000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013k",
         "material": "",
         "p58_fragility": "D3052.013k",
@@ -2765,7 +2458,6 @@
     {
         "comp_description": "Air Handling Unit - Capacity: 25000 to <40000 CFM - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 30000 CFM.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.5.2.A",
         "id": "D3052.013l",
         "material": "",
         "p58_fragility": "D3052.013l",
@@ -2774,7 +2466,6 @@
     {
         "comp_description": "Control Panel - Capacity: all - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.30.6.7.A",
         "id": "D3067.011a",
         "material": "",
         "p58_fragility": "D3067.011a",
@@ -2783,7 +2474,6 @@
     {
         "comp_description": "Control Panel - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.6.7.A",
         "id": "D3067.012a",
         "material": "",
         "p58_fragility": "D3067.012a",
@@ -2792,7 +2482,6 @@
     {
         "comp_description": "Control Panel - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.6.7.A",
         "id": "D3067.012b",
         "material": "",
         "p58_fragility": "D3067.012b",
@@ -2801,7 +2490,6 @@
     {
         "comp_description": "Control Panel - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.30.6.7.A",
         "id": "D3067.012c",
         "material": "",
         "p58_fragility": "D3067.012c",
@@ -2810,7 +2498,6 @@
     {
         "comp_description": "Fire Sprinkler Water Piping - Horizontal Mains and Branches - Old Style Victaulic - Thin Wall Steel - No bracing, SDC A or B, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, horizontal main and branches",
         "comp_detail": "SDC A/B",
-        "component": "D.40.1.1.A",
         "id": "D4011.021a",
         "material": "",
         "p58_fragility": "D4011.021a",
@@ -2819,7 +2506,6 @@
     {
         "comp_description": "Fire Sprinkler Water Piping - Horizontal Mains and Branches - Old Style Victaulic - Thin Wall Steel - No bracing, SDC C, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, horizontal main and branches",
         "comp_detail": "SDC C",
-        "component": "D.40.1.1.A",
         "id": "D4011.022a",
         "material": "",
         "p58_fragility": "D4011.022a",
@@ -2828,7 +2514,6 @@
     {
         "comp_description": "Fire Sprinkler Water Piping - Horizontal Mains and Branches - Old Style Victaulic - Thin Wall Steel - Poorly designed bracing, SDC D, E, or F , PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, horizontal main and branches",
         "comp_detail": "SDC D/E/F",
-        "component": "D.40.1.1.A",
         "id": "D4011.023a",
         "material": "",
         "p58_fragility": "D4011.023a",
@@ -2837,7 +2522,6 @@
     {
         "comp_description": "Fire Sprinkler Water Piping - Horizontal Mains and Branches - Old Style Victaulic - Thin Wall Steel - with designed bracing, SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, horizontal main and branches",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.40.1.1.A",
         "id": "D4011.024a",
         "material": "",
         "p58_fragility": "D4011.024a",
@@ -2846,7 +2530,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into unbraced lay-in tile SOFT ceiling - 6 ft. long drop maximum, SDC A or B - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC A/B - unbraced - soft ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.031a",
         "material": "",
         "p58_fragility": "D4011.031a",
@@ -2855,7 +2538,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into unbraced lay-in tile SOFT ceiling - 6 ft. long drop maximum, SDC C - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC C - unbraced - soft ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.032a",
         "material": "",
         "p58_fragility": "D4011.032a",
@@ -2864,7 +2546,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into unbraced lay-in tile SOFT ceiling - 6 ft. long drop maximum, SDC D, E, or F - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F - unbraced - soft ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.033a",
         "material": "",
         "p58_fragility": "D4011.033a",
@@ -2873,7 +2554,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into unbraced lay-in tile SOFT ceiling - 6 ft. long drop maximum, SDC D, E, or F (OSHPD or sim) - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F hospital - unbraced - soft ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.034a",
         "material": "",
         "p58_fragility": "D4011.034a",
@@ -2882,7 +2562,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into unbraced lay-in tile HARD ceiling - 6 ft. long drop maximum, SDC A or B - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC A/B - unbraced - hard ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.041a",
         "material": "",
         "p58_fragility": "D4011.041a",
@@ -2891,7 +2570,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into unbraced lay-in tile HARD ceiling - 6 ft. long drop maximum, SDC C - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC C - unbraced - hard ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.042a",
         "material": "",
         "p58_fragility": "D4011.042a",
@@ -2900,7 +2578,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into braced lay-in tile SOFT ceiling - 6 ft. long drop maximum, SDC D, E, or F - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F - brahed - soft ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.053a",
         "material": "",
         "p58_fragility": "D4011.053a",
@@ -2909,7 +2586,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into braced lay-in tile SOFT ceiling - 6 ft. long drop maximum, SDC D, E, or F (OSHPD or sim) - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F hospital - braced - soft ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.054a",
         "material": "",
         "p58_fragility": "D4011.054a",
@@ -2918,7 +2594,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into braced lay-in tile HARD ceiling - 6 ft. long drop maximum, SDC D, E, or F - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F - braced - hard ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.063a",
         "material": "",
         "p58_fragility": "D4011.063a",
@@ -2927,7 +2602,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - Dropping into braced lay-in tile HARD ceiling - 6 ft. long drop maximum, SDC D, E, or F (OSHPD or sim) - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F hospital - braced - hard ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.064a",
         "material": "",
         "p58_fragility": "D4011.064a",
@@ -2936,7 +2610,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - No Ceiling - 6 ft. long drop maximum, SDC A or B - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC A/B - no ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.071a",
         "material": "",
         "p58_fragility": "D4011.071a",
@@ -2945,7 +2618,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - No Ceiling - 6 ft. long drop maximum, SDC C - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC C - no ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.072a",
         "material": "",
         "p58_fragility": "D4011.072a",
@@ -2954,7 +2626,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - No Ceiling - 6 ft. long drop maximum, SDC D, E, or F - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F - no ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.073a",
         "material": "",
         "p58_fragility": "D4011.073a",
@@ -2963,7 +2634,6 @@
     {
         "comp_description": "Fire Sprinkler Drop Standard Threaded Steel - No Ceiling - 6 ft. long drop maximum, SDC D, E, or F (OSHPD or sim) - Costing per 100 units, Standard threaded steel drop, 6 ft. long drop maximum",
         "comp_detail": "SDC D/E/F hospital - hard ceiling",
-        "component": "D.40.1.1.B",
         "id": "D4011.074a",
         "material": "",
         "p58_fragility": "D4011.074a",
@@ -2972,7 +2642,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: <100 kVA - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 75 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.1.A",
         "id": "D5011.011a",
         "material": "",
         "p58_fragility": "D5011.011a",
@@ -2981,7 +2650,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 100 to <350 kVA - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.1.A",
         "id": "D5011.011b",
         "material": "",
         "p58_fragility": "D5011.011b",
@@ -2990,7 +2658,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 350 to <750 kVA - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.1.A",
         "id": "D5011.011c",
         "material": "",
         "p58_fragility": "D5011.011c",
@@ -2999,7 +2666,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 750 to 1500 kVA - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.1.A",
         "id": "D5011.011d",
         "material": "",
         "p58_fragility": "D5011.011d",
@@ -3008,7 +2674,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: <100 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 75 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013a",
         "material": "",
         "p58_fragility": "D5011.013a",
@@ -3017,7 +2682,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: <100 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 75 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013b",
         "material": "",
         "p58_fragility": "D5011.013b",
@@ -3026,7 +2690,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: <100 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 75 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013c",
         "material": "",
         "p58_fragility": "D5011.013c",
@@ -3035,7 +2698,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 100 to <350 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013d",
         "material": "",
         "p58_fragility": "D5011.013d",
@@ -3044,7 +2706,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 100 to <350 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013e",
         "material": "",
         "p58_fragility": "D5011.013e",
@@ -3053,7 +2714,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 100 to <350 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013f",
         "material": "",
         "p58_fragility": "D5011.013f",
@@ -3062,7 +2722,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 350 to <750 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013g",
         "material": "",
         "p58_fragility": "D5011.013g",
@@ -3071,7 +2730,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 350 to <750 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013h",
         "material": "",
         "p58_fragility": "D5011.013h",
@@ -3080,7 +2738,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 350 to <750 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013i",
         "material": "",
         "p58_fragility": "D5011.013i",
@@ -3089,7 +2746,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 750 to 1500 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013j",
         "material": "",
         "p58_fragility": "D5011.013j",
@@ -3098,7 +2754,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 750 to 1500 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013k",
         "material": "",
         "p58_fragility": "D5011.013k",
@@ -3107,7 +2762,6 @@
     {
         "comp_description": "Transformer/primary service - Capacity: 750 to 1500 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.1.A",
         "id": "D5011.013l",
         "material": "",
         "p58_fragility": "D5011.013l",
@@ -3116,7 +2770,6 @@
     {
         "comp_description": "Motor Control Center - Capacity: all - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.A",
         "id": "D5012.013a",
         "material": "",
         "p58_fragility": "D5012.013a",
@@ -3125,7 +2778,6 @@
     {
         "comp_description": "Motor Control Center - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.A",
         "id": "D5012.013b",
         "material": "",
         "p58_fragility": "D5012.013b",
@@ -3134,7 +2786,6 @@
     {
         "comp_description": "Motor Control Center - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.A",
         "id": "D5012.013c",
         "material": "",
         "p58_fragility": "D5012.013c",
@@ -3143,7 +2794,6 @@
     {
         "comp_description": "Motor Control Center - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.A",
         "id": "D5012.013d",
         "material": "",
         "p58_fragility": "D5012.013d",
@@ -3152,7 +2802,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 100 to <350 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.B",
         "id": "D5012.021a",
         "material": "",
         "p58_fragility": "D5012.021a",
@@ -3161,7 +2810,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 350 to <750 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.B",
         "id": "D5012.021b",
         "material": "",
         "p58_fragility": "D5012.021b",
@@ -3170,7 +2818,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 750 to <1200 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.B",
         "id": "D5012.021c",
         "material": "",
         "p58_fragility": "D5012.021c",
@@ -3179,7 +2826,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 1200 to 2000 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.B",
         "id": "D5012.021d",
         "material": "",
         "p58_fragility": "D5012.021d",
@@ -3188,7 +2834,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 100 to <350 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023a",
         "material": "",
         "p58_fragility": "D5012.023a",
@@ -3197,7 +2842,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 100 to <350 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023b",
         "material": "",
         "p58_fragility": "D5012.023b",
@@ -3206,7 +2850,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 100 to <350 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023c",
         "material": "",
         "p58_fragility": "D5012.023c",
@@ -3215,7 +2858,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 350 to <750 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023d",
         "material": "",
         "p58_fragility": "D5012.023d",
@@ -3224,7 +2866,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 350 to <750 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023e",
         "material": "",
         "p58_fragility": "D5012.023e",
@@ -3233,7 +2874,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 350 to <750 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023f",
         "material": "",
         "p58_fragility": "D5012.023f",
@@ -3242,7 +2882,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 750 to <1200 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023g",
         "material": "",
         "p58_fragility": "D5012.023g",
@@ -3251,7 +2890,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 750 to <1200 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023h",
         "material": "",
         "p58_fragility": "D5012.023h",
@@ -3260,7 +2898,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 750 to <1200 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023i",
         "material": "",
         "p58_fragility": "D5012.023i",
@@ -3269,7 +2906,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 1200 to 2000 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023j",
         "material": "",
         "p58_fragility": "D5012.023j",
@@ -3278,7 +2914,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 1200 to 2000 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023k",
         "material": "",
         "p58_fragility": "D5012.023k",
@@ -3287,7 +2922,6 @@
     {
         "comp_description": "Low Voltage Switchgear - Capacity: 1200 to 2000 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.B",
         "id": "D5012.023l",
         "material": "",
         "p58_fragility": "D5012.023l",
@@ -3296,7 +2930,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 100 to <350 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.C",
         "id": "D5012.031a",
         "material": "",
         "p58_fragility": "D5012.031a",
@@ -3305,7 +2938,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 350 to <750 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.C",
         "id": "D5012.031b",
         "material": "",
         "p58_fragility": "D5012.031b",
@@ -3314,7 +2946,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 750 to <1200 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.C",
         "id": "D5012.031c",
         "material": "",
         "p58_fragility": "D5012.031c",
@@ -3323,7 +2954,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 1200 to 2000 Amp - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Unanchored",
-        "component": "D.50.1.2.C",
         "id": "D5012.031d",
         "material": "",
         "p58_fragility": "D5012.031d",
@@ -3332,7 +2962,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 100 to <350 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033a",
         "material": "",
         "p58_fragility": "D5012.033a",
@@ -3341,7 +2970,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 100 to <350 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033b",
         "material": "",
         "p58_fragility": "D5012.033b",
@@ -3350,7 +2978,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 100 to <350 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 225 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033c",
         "material": "",
         "p58_fragility": "D5012.033c",
@@ -3359,7 +2986,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 350 to <750 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033d",
         "material": "",
         "p58_fragility": "D5012.033d",
@@ -3368,7 +2994,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 350 to <750 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033e",
         "material": "",
         "p58_fragility": "D5012.033e",
@@ -3377,7 +3002,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 350 to <750 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 400 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033f",
         "material": "",
         "p58_fragility": "D5012.033f",
@@ -3386,7 +3010,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 750 to <1200 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033g",
         "material": "",
         "p58_fragility": "D5012.033g",
@@ -3395,7 +3018,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 750 to <1200 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033h",
         "material": "",
         "p58_fragility": "D5012.033h",
@@ -3404,7 +3026,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 750 to <1200 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 800 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033i",
         "material": "",
         "p58_fragility": "D5012.033i",
@@ -3413,7 +3034,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 1200 to 2000 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033j",
         "material": "",
         "p58_fragility": "D5012.033j",
@@ -3422,7 +3042,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 1200 to 2000 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033k",
         "material": "",
         "p58_fragility": "D5012.033k",
@@ -3431,7 +3050,6 @@
     {
         "comp_description": "Distribution Panel - Capacity: 1200 to 2000 Amp - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 1600 Amp.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.1.2.C",
         "id": "D5012.033l",
         "material": "",
         "p58_fragility": "D5012.033l",
@@ -3440,7 +3058,6 @@
     {
         "comp_description": "Battery Rack - Capacity: all - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.50.9.2.A",
         "id": "D5092.011a",
         "material": "",
         "p58_fragility": "D5092.011a",
@@ -3449,7 +3066,6 @@
     {
         "comp_description": "Battery Rack - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.A",
         "id": "D5092.013a",
         "material": "",
         "p58_fragility": "D5092.013a",
@@ -3458,7 +3074,6 @@
     {
         "comp_description": "Battery Rack - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.A",
         "id": "D5092.013b",
         "material": "",
         "p58_fragility": "D5092.013b",
@@ -3467,7 +3082,6 @@
     {
         "comp_description": "Battery Rack - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.A",
         "id": "D5092.013c",
         "material": "",
         "p58_fragility": "D5092.013c",
@@ -3476,7 +3090,6 @@
     {
         "comp_description": "Battery Charger - Capacity: all - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Unanchored",
-        "component": "D.50.9.2.B",
         "id": "D5092.021a",
         "material": "",
         "p58_fragility": "D5092.021a",
@@ -3485,7 +3098,6 @@
     {
         "comp_description": "Battery Charger - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.B",
         "id": "D5092.023a",
         "material": "",
         "p58_fragility": "D5092.023a",
@@ -3494,7 +3106,6 @@
     {
         "comp_description": "Battery Charger - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.B",
         "id": "D5092.023b",
         "material": "",
         "p58_fragility": "D5092.023b",
@@ -3503,7 +3114,6 @@
     {
         "comp_description": "Battery Charger - Capacity: all - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.B",
         "id": "D5092.023c",
         "material": "",
         "p58_fragility": "D5092.023c",
@@ -3512,7 +3122,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 100 to <350 kVA - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.9.2.C",
         "id": "D5092.031a",
         "material": "",
         "p58_fragility": "D5092.031a",
@@ -3521,7 +3130,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 350 to <750 kVA - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.9.2.C",
         "id": "D5092.031b",
         "material": "",
         "p58_fragility": "D5092.031b",
@@ -3530,7 +3138,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 750 to 1200 kVA - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.9.2.C",
         "id": "D5092.031c",
         "material": "",
         "p58_fragility": "D5092.031c",
@@ -3539,7 +3146,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 1200 to 2000 kVa - Unanchored equipment that is not vibration isolated - Equipment fragility only - Costing is per unit and is based upon 1500 kVa.",
         "comp_detail": "Unanchored",
-        "component": "D.50.9.2.C",
         "id": "D5092.031d",
         "material": "",
         "p58_fragility": "D5092.031d",
@@ -3548,7 +3154,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 100 to <350 kVA - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032a",
         "material": "",
         "p58_fragility": "D5092.032a",
@@ -3557,7 +3162,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 100 to <350 kVA - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032b",
         "material": "",
         "p58_fragility": "D5092.032b",
@@ -3566,7 +3170,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 100 to <350 kVA - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032c",
         "material": "",
         "p58_fragility": "D5092.032c",
@@ -3575,7 +3178,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 350 to <750 kVA - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032d",
         "material": "",
         "p58_fragility": "D5092.032d",
@@ -3584,7 +3186,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 350 to <750 kVA - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032e",
         "material": "",
         "p58_fragility": "D5092.032e",
@@ -3593,7 +3194,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 350 to <750 kVA - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032f",
         "material": "",
         "p58_fragility": "D5092.032f",
@@ -3602,7 +3202,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 750 to 1200 kVA - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032g",
         "material": "",
         "p58_fragility": "D5092.032g",
@@ -3611,7 +3210,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 750 to 1200 kVA - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032h",
         "material": "",
         "p58_fragility": "D5092.032h",
@@ -3620,7 +3218,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 750 to 1200 kVA - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032i",
         "material": "",
         "p58_fragility": "D5092.032i",
@@ -3629,7 +3226,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 1200 to 2000 kVa - Vibration isolated equipment that is not snubbed or restrained - Anchorage fragility only - Costing is per unit and is based upon 1500 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032j",
         "material": "",
         "p58_fragility": "D5092.032j",
@@ -3638,7 +3234,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 1200 to 2000 kVa - Vibration isolated equipment that is not snubbed or restrained - Equipment fragility only - Costing is per unit and is based upon 1500 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032k",
         "material": "",
         "p58_fragility": "D5092.032k",
@@ -3647,7 +3242,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 1200 to 2000 kVa - Vibration isolated equipment that is not snubbed or restrained - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 1500 kVa.",
         "comp_detail": "Vibration isolated equipment that is not snubbed or restrained",
-        "component": "D.50.9.2.C",
         "id": "D5092.032l",
         "material": "",
         "p58_fragility": "D5092.032l",
@@ -3656,7 +3250,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 100 to <350 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033a",
         "material": "",
         "p58_fragility": "D5092.033a",
@@ -3665,7 +3258,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 100 to <350 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033b",
         "material": "",
         "p58_fragility": "D5092.033b",
@@ -3674,7 +3266,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 100 to <350 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 250 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033c",
         "material": "",
         "p58_fragility": "D5092.033c",
@@ -3683,7 +3274,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 350 to <750 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033d",
         "material": "",
         "p58_fragility": "D5092.033d",
@@ -3692,7 +3282,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 350 to <750 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033e",
         "material": "",
         "p58_fragility": "D5092.033e",
@@ -3701,7 +3290,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 350 to <750 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033f",
         "material": "",
         "p58_fragility": "D5092.033f",
@@ -3710,7 +3298,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 750 to 1200 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033g",
         "material": "",
         "p58_fragility": "D5092.033g",
@@ -3719,7 +3306,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 750 to 1200 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033h",
         "material": "",
         "p58_fragility": "D5092.033h",
@@ -3728,7 +3314,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 750 to 1200 kVA - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 1000 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033i",
         "material": "",
         "p58_fragility": "D5092.033i",
@@ -3737,7 +3322,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 1200 to 2000 kVa - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Anchorage fragility only - Costing is per unit and is based upon 1500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033j",
         "material": "",
         "p58_fragility": "D5092.033j",
@@ -3746,7 +3330,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 1200 to 2000 kVa - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Equipment fragility only - Costing is per unit and is based upon 1500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033k",
         "material": "",
         "p58_fragility": "D5092.033k",
@@ -3755,7 +3338,6 @@
     {
         "comp_description": "Diesel generator - Capacity: 1200 to 2000 kVa - Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints - Combined anchorage/isolator & equipment fragility - Costing is per unit and is based upon 1500 kVa.",
         "comp_detail": "Equipment that is either hard anchored or is vibration isolated with seismic snubbers/restraints",
-        "component": "D.50.9.2.C",
         "id": "D5092.033l",
         "material": "",
         "p58_fragility": "D5092.033l",
@@ -3764,7 +3346,6 @@
     {
         "comp_description": "Modular office work stations. - Unanchored and installed per manufacturer's recommendations on a carpeted floor.",
         "comp_detail": "Unsecured",
-        "component": "E.20.2.2.A",
         "id": "E2022.001",
         "material": "",
         "p58_fragility": "E2022.001",
@@ -3773,7 +3354,6 @@
     {
         "comp_description": "Unsecured fragile objects on shelves, unknown restraint - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "Unsecured",
-        "component": "E.20.2.2.B",
         "id": "E2022.010",
         "material": "",
         "p58_fragility": "E2022.010",
@@ -3782,7 +3362,6 @@
     {
         "comp_description": "Fragile contents secured by museum putty, Velcro or other weak but sticky stuff - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "Secured",
-        "component": "E.20.2.2.B",
         "id": "E2022.011",
         "material": "",
         "p58_fragility": "E2022.011",
@@ -3791,7 +3370,6 @@
     {
         "comp_description": "Fragile contents on shelves in storage cabinets with latches - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "Secured",
-        "component": "E.20.2.2.B",
         "id": "E2022.012",
         "material": "",
         "p58_fragility": "E2022.012",
@@ -3800,7 +3378,6 @@
     {
         "comp_description": "Unsecured fragile objects on shelves, low friction surface - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "Unsecured",
-        "component": "E.20.2.2.B",
         "id": "E2022.013",
         "material": "",
         "p58_fragility": "E2022.013",
@@ -3809,7 +3386,6 @@
     {
         "comp_description": "Home entertainment equipment, unknown installation - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "",
-        "component": "E.20.2.2.C",
         "id": "E2022.020",
         "material": "",
         "p58_fragility": "E2022.020",
@@ -3818,7 +3394,6 @@
     {
         "comp_description": "Electronic equipment on wall mount brackets - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "",
-        "component": "E.20.2.2.C",
         "id": "E2022.021",
         "material": "",
         "p58_fragility": "E2022.021",
@@ -3827,7 +3402,6 @@
     {
         "comp_description": "Desktop electronics including computers, monitors, stereos, etc on a slip resistant surface - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "",
-        "component": "E.20.2.2.C",
         "id": "E2022.022",
         "material": "",
         "p58_fragility": "E2022.022",
@@ -3836,7 +3410,6 @@
     {
         "comp_description": "Desktop electronics including computers, monitors, stereos, etc, smooth surface - Costing to be furnished by user. Consequence data assumes 16 SF of damage area.",
         "comp_detail": "",
-        "component": "E.20.2.2.C",
         "id": "E2022.023",
         "material": "",
         "p58_fragility": "E2022.023",
@@ -3845,7 +3418,6 @@
     {
         "comp_description": "Bookcase, 2 shelves, unanchored laterally - Standard bookcase, unanchored laterally. Bookcase is 12-5/8\" deep x 29\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.102a",
         "material": "",
         "p58_fragility": "E2022.102a",
@@ -3854,7 +3426,6 @@
     {
         "comp_description": "Bookcase, 2 shelves, anchored laterally - Standard bookcase, anchored laterally. Bookcase is 12-5/8\" deep x 29\" tall.",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.102b",
         "material": "",
         "p58_fragility": "E2022.102b",
@@ -3863,7 +3434,6 @@
     {
         "comp_description": "Bookcase, 3 shelves, unanchored laterally - Standard bookcase, unanchored laterally. Bookcase is 12-5/8\" deep x 41\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.103a",
         "material": "",
         "p58_fragility": "E2022.103a",
@@ -3872,7 +3442,6 @@
     {
         "comp_description": "Bookcase, 3 shelves, anchored laterally - Standard bookcase, anchored laterally. Bookcase is 12-5/8\" deep x 41\" tall.",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.103b",
         "material": "",
         "p58_fragility": "E2022.103b",
@@ -3881,7 +3450,6 @@
     {
         "comp_description": "Bookcase, 4 shelves, unanchored laterally - Standard bookcase, unanchored laterally. Bookcase is 12-5/8\" deep x 56\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.104a",
         "material": "",
         "p58_fragility": "E2022.104a",
@@ -3890,7 +3458,6 @@
     {
         "comp_description": "Bookcase, 4 shelves, anchored laterally - Standard bookcase, anchored laterally. Bookcase is 12-5/8\" deep x 56\" tall.",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.104b",
         "material": "",
         "p58_fragility": "E2022.104b",
@@ -3899,7 +3466,6 @@
     {
         "comp_description": "Bookcase, 5 shelves, unanchored laterally - Standard bookcase, unanchored laterally. Bookcase is 12-5/8\" deep x 71\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.105a",
         "material": "",
         "p58_fragility": "E2022.105a",
@@ -3908,7 +3474,6 @@
     {
         "comp_description": "Bookcase, 5 shelves, anchored laterally - Standard bookcase, anchored laterally. Bookcase is 12-5/8\" deep x 71\" tall.",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.D",
         "id": "E2022.105b",
         "material": "",
         "p58_fragility": "E2022.105b",
@@ -3917,7 +3482,6 @@
     {
         "comp_description": "Bookcase, 6 shelves, unanchored laterally - Standard bookcase, unanchored laterally. Bookcase is 12-5/8\" deep x 81-1/4\" tall",
         "comp_detail": "Standard",
-        "component": "E.20.2.2.D",
         "id": "E2022.106a",
         "material": "",
         "p58_fragility": "E2022.106a",
@@ -3926,7 +3490,6 @@
     {
         "comp_description": "Bookcase, 6 shelves, anchored laterally - Standard bookcase, anchored laterally. Bookcase is 12-5/8\" deep x 81-1/4\" tall.",
         "comp_detail": "Standard",
-        "component": "E.20.2.2.D",
         "id": "E2022.106b",
         "material": "",
         "p58_fragility": "E2022.106b",
@@ -3935,7 +3498,6 @@
     {
         "comp_description": "Vertical Filing Cabinet, 2 drawer, unanchored laterally - Filing cabinet, unanchored laterally. Cabinet has 2 drawers and is 15\" deep x 24\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.112a",
         "material": "",
         "p58_fragility": "E2022.112a",
@@ -3944,7 +3506,6 @@
     {
         "comp_description": "Vertical Filing Cabinet, 2 drawer, anchored laterally - Filing cabinet, anchored laterally. Cabinet has 2 drawers and is 15\" deep x 24\" tall",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.112b",
         "material": "",
         "p58_fragility": "E2022.112b",
@@ -3953,7 +3514,6 @@
     {
         "comp_description": "Vertical Filing Cabinet, 4 drawer, unanchored laterally - Filing cabinet, unanchored laterally. Cabinet has 4 drawers and is 15\" deep x 52\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.114a",
         "material": "",
         "p58_fragility": "E2022.114a",
@@ -3962,7 +3522,6 @@
     {
         "comp_description": "Vertical Filing Cabinet, 4 drawer, anchored laterally - Filing cabinet, anchored laterally. Cabinet has 4 drawers and is 15\" deep x 52\" tall",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.114b",
         "material": "",
         "p58_fragility": "E2022.114b",
@@ -3971,7 +3530,6 @@
     {
         "comp_description": "Lateral Filing Cabinet, 2 drawer, unanchored laterally - Filing cabinet, unanchored laterally. Cabinet has 4 drawers and is 18.6\" deep x 52.5\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.124a",
         "material": "",
         "p58_fragility": "E2022.124a",
@@ -3980,7 +3538,6 @@
     {
         "comp_description": "Lateral Filing Cabinet, 2 drawer, anchored laterally - Filing cabinet, anchored laterally. Cabinet has 4 drawers and is 18.6\" deep x 52.5\" tall",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.124b",
         "material": "",
         "p58_fragility": "E2022.124b",
@@ -3989,7 +3546,6 @@
     {
         "comp_description": "Lateral Filing Cabinet, 4 drawer, unanchored laterally - Filing cabinet, unanchored laterally. Cabinet has 5 drawers and is 18.6\" deep x 67.75\" tall",
         "comp_detail": "Unanchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.125a",
         "material": "",
         "p58_fragility": "E2022.125a",
@@ -3998,7 +3554,6 @@
     {
         "comp_description": "Lateral Filing Cabinet, 4 drawer, anchored laterally - Filing cabinet, anchored laterally. Cabinet has 5 drawers and is 18.6\" deep x 67.75\" tall",
         "comp_detail": "Anchored",
-        "component": "E.20.2.2.E",
         "id": "E2022.125b",
         "material": "",
         "p58_fragility": "E2022.125b",
@@ -4007,7 +3562,6 @@
     {
         "comp_description": "Storage racks designed and installed before 2007, big box retail (12' to 15' tall) - Standard pallet back to back storage rack. Three to five levels tall with total height from 15 to 20 ft. Costing assumes one single side access rack. Costing of rack and restocking based upon 50 LF of rack. Costing of rack contents to be furnished by user.",
         "comp_detail": "",
-        "component": "F.10.1.2.A",
         "id": "F1012.001",
         "material": "",
         "p58_fragility": "F1012.001",
@@ -4016,7 +3570,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC A/B",
-        "component": "D.20.2.2.A",
         "id": "D2021.011a",
         "material": "piping",
         "p58_fragility": "D2021.011a",
@@ -4025,7 +3578,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, BRACING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC A/B",
-        "component": "D.20.2.2.A",
         "id": "D2021.011b",
         "material": "bracing",
         "p58_fragility": "D2021.011b",
@@ -4034,7 +3586,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC C",
-        "component": "D.20.2.2.A",
         "id": "D2021.012a",
         "material": "piping",
         "p58_fragility": "D2021.012a",
@@ -4043,7 +3594,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, BRACING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC C",
-        "component": "D.20.2.2.A",
         "id": "D2021.012b",
         "material": "bracing",
         "p58_fragility": "D2021.012b",
@@ -4052,7 +3602,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F",
-        "component": "D.20.2.2.A",
         "id": "D2021.013a",
         "material": "piping",
         "p58_fragility": "D2021.013a",
@@ -4061,7 +3610,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, BRACING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F",
-        "component": "D.20.2.2.A",
         "id": "D2021.013b",
         "material": "bracing",
         "p58_fragility": "D2021.013b",
@@ -4070,7 +3618,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F hosptial",
-        "component": "D.20.2.2.A",
         "id": "D2021.014a",
         "material": "piping",
         "p58_fragility": "D2021.014a",
@@ -4079,7 +3626,6 @@
     {
         "comp_description": "Cold or Hot Potable - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), BRACING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F hosptial",
-        "component": "D.20.2.2.A",
         "id": "D2021.014b",
         "material": "bracing",
         "p58_fragility": "D2021.014b",
@@ -4088,7 +3634,6 @@
     {
         "comp_description": "Cold or Hot Potable Water Piping (dia > 2.5 inches), SDC A or B, PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC A/B",
-        "component": "D.20.2.2.A",
         "id": "D2021.021a",
         "material": "piping",
         "p58_fragility": "D2021.021a",
@@ -4097,7 +3642,6 @@
     {
         "comp_description": "Cold or Hot Potable Water Piping (dia > 2.5 inches), SDC C, PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC C",
-        "component": "D.20.2.2.A",
         "id": "D2021.022a",
         "material": "piping",
         "p58_fragility": "D2021.022a",
@@ -4106,7 +3650,6 @@
     {
         "comp_description": "Cold or Hot Potable Water Piping (dia > 2.5 inches), SDC D,E,F, PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F",
-        "component": "D.20.2.2.A",
         "id": "D2021.023a",
         "material": "piping",
         "p58_fragility": "D2021.023a",
@@ -4115,7 +3658,6 @@
     {
         "comp_description": "Cold or Hot Potable Water Piping (dia > 2.5 inches), SDC D,E,F, BRACING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F",
-        "component": "D.20.2.2.A",
         "id": "D2021.023b",
         "material": "bracing",
         "p58_fragility": "D2021.023b",
@@ -4124,7 +3666,6 @@
     {
         "comp_description": "Cold or Hot Potable Water Piping (dia > 2.5 inches), SDC D,E,F (OSPHD or sim), PIPING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F hosptial",
-        "component": "D.20.2.2.A",
         "id": "D2021.024a",
         "material": "piping",
         "p58_fragility": "D2021.024a",
@@ -4133,7 +3674,6 @@
     {
         "comp_description": "Cold or Hot Potable Water Piping (dia > 2.5 inches), SDC D,E,F (OSPHD or sim), BRACING FRAGILITY - Potable water. Costing based upon 1000 ft segments.",
         "comp_detail": "SDC D/E/F hosptial",
-        "component": "D.20.2.2.A",
         "id": "D2021.024b",
         "material": "bracing",
         "p58_fragility": "D2021.024b",
@@ -4142,7 +3682,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.4.A",
         "id": "D2022.011a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2022.011a",
@@ -4151,7 +3690,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, BRACING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.4.A",
         "id": "D2022.011b",
         "material": "Bracing",
         "p58_fragility": "D2022.011b",
@@ -4160,7 +3698,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC C",
-        "component": "D.30.4.4.A",
         "id": "D2022.012a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2022.012a",
@@ -4169,7 +3706,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, BRACING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC C",
-        "component": "D.30.4.4.A",
         "id": "D2022.012b",
         "material": "Bracing",
         "p58_fragility": "D2022.012b",
@@ -4178,7 +3714,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.4.A",
         "id": "D2022.013a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2022.013a",
@@ -4187,7 +3722,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, BRACING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.4.A",
         "id": "D2022.013b",
         "material": "Bracing",
         "p58_fragility": "D2022.013b",
@@ -4196,7 +3730,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.4.A",
         "id": "D2022.014a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2022.014a",
@@ -4205,7 +3738,6 @@
     {
         "comp_description": "Heating hot Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), BRACING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.4.A",
         "id": "D2022.014b",
         "material": "Bracing",
         "p58_fragility": "D2022.014b",
@@ -4214,7 +3746,6 @@
     {
         "comp_description": "Heating hot Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC A or B, PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.4.A",
         "id": "D2022.021a",
         "material": "Welded steel piping",
         "p58_fragility": "D2022.021a",
@@ -4223,7 +3754,6 @@
     {
         "comp_description": "Heating hot Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC C, PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC C",
-        "component": "D.30.4.4.A",
         "id": "D2022.022a",
         "material": "Welded steel piping",
         "p58_fragility": "D2022.022a",
@@ -4232,7 +3762,6 @@
     {
         "comp_description": "Heating hot Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F, PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.4.A",
         "id": "D2022.023a",
         "material": "Welded steel piping",
         "p58_fragility": "D2022.023a",
@@ -4241,7 +3770,6 @@
     {
         "comp_description": "Heating hot Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F, BRACING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.4.A",
         "id": "D2022.023b",
         "material": "Bracing",
         "p58_fragility": "D2022.023b",
@@ -4250,7 +3778,6 @@
     {
         "comp_description": "Heating hot Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.4.A",
         "id": "D2022.024a",
         "material": "Welded steel piping",
         "p58_fragility": "D2022.024a",
@@ -4259,7 +3786,6 @@
     {
         "comp_description": "Heating hot Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F (OSHPD or sim), BRACING FRAGILITY - Heating water. Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.4.A",
         "id": "D2022.024b",
         "material": "Bracing",
         "p58_fragility": "D2022.024b",
@@ -4268,7 +3794,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/flexible couplings, SDC A,B, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC A/B with flexibile couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.011b",
         "material": "Cast iron",
         "p58_fragility": "D2031.011b",
@@ -4277,7 +3802,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/flexible couplings, SDC C, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC C with flexibile couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.012b",
         "material": "Cast iron",
         "p58_fragility": "D2031.012b",
@@ -4286,7 +3810,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/flexible couplings, SDC D,E,F, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC D/E/F with flexibile couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.013b",
         "material": "Cast iron",
         "p58_fragility": "D2031.013b",
@@ -4295,7 +3818,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/flexible couplings, SDC D,E,F (OSHPD or sim), BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC D/E/F hosptial - flexibile couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.014b",
         "material": "Cast iron",
         "p58_fragility": "D2031.014b",
@@ -4304,7 +3826,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC A,B, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC A/B with bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.021a",
         "material": "Cast iron piping",
         "p58_fragility": "D2031.021a",
@@ -4313,7 +3834,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC A,B, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC A/B with bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.021b",
         "material": "Bracing",
         "p58_fragility": "D2031.021b",
@@ -4322,7 +3842,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC C, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC C with bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.022a",
         "material": "Cast iron piping",
         "p58_fragility": "D2031.022a",
@@ -4331,7 +3850,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC C, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC C with bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.022b",
         "material": "Bracing",
         "p58_fragility": "D2031.022b",
@@ -4340,7 +3858,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC D,E,F, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC D/E/F with bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.023a",
         "material": "Cast iron piping",
         "p58_fragility": "D2031.023a",
@@ -4349,7 +3866,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC D,E,F, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC D/E/F with bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.023b",
         "material": "Bracing",
         "p58_fragility": "D2031.023b",
@@ -4358,7 +3874,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC D,E,F (OSHPD or sim), PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC D/E/F hospital - bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.024a",
         "material": "Cast iron piping",
         "p58_fragility": "D2031.024a",
@@ -4367,7 +3882,6 @@
     {
         "comp_description": "Sanitary Waste Piping - Cast Iron w/bell and spigot couplings, SDC D,E,F (OSHPD or sim), BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe",
         "comp_detail": "SDC D/E/F hospital - bell and spigot couplings",
-        "component": "D.20.3.1.A",
         "id": "D2031.024b",
         "material": "Bracing",
         "p58_fragility": "D2031.024b",
@@ -4376,7 +3890,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.5.A",
         "id": "D2051.011a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2051.011a",
@@ -4385,7 +3898,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.5.A",
         "id": "D2051.011b",
         "material": "Bracing",
         "p58_fragility": "D2051.011b",
@@ -4394,7 +3906,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC C",
-        "component": "D.30.4.5.A",
         "id": "D2051.012a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2051.012a",
@@ -4403,7 +3914,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC C",
-        "component": "D.30.4.5.A",
         "id": "D2051.012b",
         "material": "Bracing",
         "p58_fragility": "D2051.012b",
@@ -4412,7 +3922,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.5.A",
         "id": "D2051.013a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2051.013a",
@@ -4421,7 +3930,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.5.A",
         "id": "D2051.013b",
         "material": "Bracing",
         "p58_fragility": "D2051.013b",
@@ -4430,7 +3938,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.5.A",
         "id": "D2051.014a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2051.014a",
@@ -4439,7 +3946,6 @@
     {
         "comp_description": "Chilled Water Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.5.A",
         "id": "D2051.014b",
         "material": "Bracing",
         "p58_fragility": "D2051.014b",
@@ -4448,7 +3954,6 @@
     {
         "comp_description": "Chilled Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC A or B, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.5.A",
         "id": "D2051.021a",
         "material": "Welded steel piping",
         "p58_fragility": "D2051.021a",
@@ -4457,7 +3962,6 @@
     {
         "comp_description": "Chilled Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC A or B, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.5.A",
         "id": "D2051.021b",
         "material": "Bracing",
         "p58_fragility": "D2051.021b",
@@ -4466,7 +3970,6 @@
     {
         "comp_description": "Chilled Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC C, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC C",
-        "component": "D.30.4.5.A",
         "id": "D2051.022a",
         "material": "Welded steel piping",
         "p58_fragility": "D2051.022a",
@@ -4475,7 +3978,6 @@
     {
         "comp_description": "Chilled Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.5.A",
         "id": "D2051.023a",
         "material": "Welded steel piping",
         "p58_fragility": "D2051.023a",
@@ -4484,7 +3986,6 @@
     {
         "comp_description": "Chilled Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.5.A",
         "id": "D2051.023b",
         "material": "Bracing",
         "p58_fragility": "D2051.023b",
@@ -4493,7 +3994,6 @@
     {
         "comp_description": "Chilled Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.5.A",
         "id": "D2051.024a",
         "material": "Welded steel piping",
         "p58_fragility": "D2051.024a",
@@ -4502,7 +4002,6 @@
     {
         "comp_description": "Chilled Water Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC D, E, or F (OSHPD or sim), BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.5.A",
         "id": "D2051.024b",
         "material": "Bracing",
         "p58_fragility": "D2051.024b",
@@ -4511,7 +4010,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.3.A",
         "id": "D2061.011a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2061.011a",
@@ -4520,7 +4018,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC A or B, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.3.A",
         "id": "D2061.011b",
         "material": "Bracing",
         "p58_fragility": "D2061.011b",
@@ -4529,7 +4026,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC C",
-        "component": "D.30.4.3.A",
         "id": "D2061.012a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2061.012a",
@@ -4538,7 +4034,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC C, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC C",
-        "component": "D.30.4.3.A",
         "id": "D2061.012b",
         "material": "Bracing",
         "p58_fragility": "D2061.012b",
@@ -4547,7 +4042,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.3.A",
         "id": "D2061.013a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2061.013a",
@@ -4556,7 +4050,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F, BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F",
-        "component": "D.30.4.3.A",
         "id": "D2061.013b",
         "material": "Bracing",
         "p58_fragility": "D2061.013b",
@@ -4565,7 +4058,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.3.A",
         "id": "D2061.014a",
         "material": "Threaded steel piping",
         "p58_fragility": "D2061.014a",
@@ -4574,7 +4066,6 @@
     {
         "comp_description": "Steam Piping - Small Diameter Threaded Steel - (2.5 inches in diameter or less), SDC D, E, or F (OSHPD or sim), BRACING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe 2.5 inches in diameter or less",
         "comp_detail": "SDC D/E/F hospital",
-        "component": "D.30.4.3.A",
         "id": "D2061.014b",
         "material": "Bracing",
         "p58_fragility": "D2061.014b",
@@ -4583,7 +4074,6 @@
     {
         "comp_description": "Steam Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC A or B, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC A/B",
-        "component": "D.30.4.3.A",
         "id": "D2061.021a",
         "material": "Welded steel piping",
         "p58_fragility": "D2061.021a",
@@ -4592,7 +4082,6 @@
     {
         "comp_description": "Steam Piping - Large Diameter Welded Steel - (greater than 2.5 inches in diameter), SDC C, PIPING FRAGILITY - Costing based upon 1000 ft segments of pipe, pipe greater than 2.5 inches in diameter",
         "comp_detail": "SDC C",
-        "component": "D.30.4.3.A",
         "id": "D2061.022a",
         "material": "Welded steel piping",
         "p58_fragility": "D2061.022a",

--- a/resources/example_data/component_fragility_bridge.json
+++ b/resources/example_data/component_fragility_bridge.json
@@ -1,0 +1,7 @@
+[
+  {
+    "_comment": "This is an example for a ComponentFragilityModelBridge object. It links a Component (by component_id) to a FragilityModel (by id).",
+    "component": "A.10.1.1.A",
+    "fragility_model": "FM001"
+  }
+]

--- a/resources/example_data/fragility_model.json
+++ b/resources/example_data/fragility_model.json
@@ -1,9 +1,8 @@
 [
   {
-    "_comment": "This is an example for a FragilityModel object. The id should be unique, component references a component_id, and p58_fragility is the FEMA P-58 fragility identifier.",
+    "_comment": "This is an example for a FragilityModel object. The id should be unique and p58_fragility is the FEMA P-58 fragility identifier. Component relationships are managed through component_fragility_model_bridge.json.",
     "id": "FM001",
     "p58_fragility": "B2011.001a",
-    "component": "A.10.1.1.A",
     "comp_detail": "Brief component detail description",
     "material": "Steel",
     "size_class": "Medium",


### PR DESCRIPTION
## Summary

- Introduce `ComponentFragilityModelBridge` model to replace the direct
  `component` ForeignKey on `FragilityModel` with an explicit many-to-many
  relationship, mirroring the existing `ExperimentFragilityModelBridge` pattern
- Add migrations (0015–0017) that create the bridge table, populate it from
  existing FK data, and remove the FK column
- Update serializers, ingest/export commands, and admin registration for the
  new model
- Regenerate canonical JSON data and fixture to reflect the new schema
- Update the schema change workflow in README.md to document the detailed
  multi-step procedure for data migrations
- Add serializer tests for `ComponentFragilityModelBridgeSerializer` and
  update all existing tests to match the new schema
- Update example data templates in `resources/example_data/`

## Motivation

Several components share identical fragility models. The previous one-to-many
relationship (FK on `FragilityModel`) prevented representing this. The new
many-to-many bridge table enables future deduplication of fragility models
across components without data loss.

## Test plan

- [x] All 84 unit tests pass (`python manage.py test ned_app.tests`)
- [x] Round-trip data integrity tests pass (ingest → export → ingest is
  lossless)
- [x] Ruff linting and formatting checks pass
- [x] Bridge table contains exactly 511 entries matching the original FK
  relationships