### PR TITLE
Restructure Reference PK from CharField to auto BigAutoField

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ python manage.py migrate
 Export the migrated database to generate the updated canonical JSON files and fixture:
 ```bash
 python manage.py export_data --output_dir resources/data/
-python manage.py dumpdata ned_app --indent 2 > ned_app/fixtures/initial_data.json
+python manage.py dumpdata --indent 2 --exclude contenttypes --exclude auth.permission -o ned_app/fixtures/initial_data.json
 ```
 
 #### Step 6: Verification (The "Round-Trip" Protocol)

--- a/ned_app/admin.py
+++ b/ned_app/admin.py
@@ -17,7 +17,14 @@ from ned_app.models import (
 @admin.register(Reference)
 class ReferenceAdmin(admin.ModelAdmin):
     # how column data is displayed in the report for all entered data
-    list_display = ('id', 'title', 'author', 'year', 'study_type', 'comp_type')
+    list_display = (
+        'reference_id',
+        'title',
+        'author',
+        'year',
+        'study_type',
+        'comp_type',
+    )
 
 
 @admin.register(Experiment)

--- a/ned_app/management/commands/export_data.py
+++ b/ned_app/management/commands/export_data.py
@@ -99,7 +99,7 @@ class Command(BaseCommand):
         data = []
         for ref in references:
             ref_data = {
-                'id': ref.id,
+                'reference_id': ref.reference_id,
                 'study_type': ref.study_type,
                 'comp_type': ref.comp_type,
                 'pdf_saved': ref.pdf_saved,

--- a/ned_app/management/commands/ingest.py
+++ b/ned_app/management/commands/ingest.py
@@ -161,7 +161,12 @@ class Command(BaseCommand):
 
             except (ValidationError, Exception) as ex:
                 failed_count += 1
-                record_id = item.get('id') or item.get('component_id') or 'unknown'
+                record_id = (
+                    item.get('id')
+                    or item.get('reference_id')
+                    or item.get('component_id')
+                    or 'unknown'
+                )
                 self.stderr.write(
                     f"Error processing {model_name} record '{record_id}': {ex}"
                 )

--- a/ned_app/management/commands/ingest.py
+++ b/ned_app/management/commands/ingest.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
                 'model': Reference,
                 'serializer': ReferenceSerializer,
                 'file': 'reference.json',
-                'lookup_field': ['id'],
+                'lookup_field': ['reference_id'],
             },
             {
                 'model': Component,

--- a/ned_app/migrations/0018_reference_add_reference_id_and_temp_fks.py
+++ b/ned_app/migrations/0018_reference_add_reference_id_and_temp_fks.py
@@ -1,0 +1,49 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('ned_app', '0017_remove_fragilitymodel_component'),
+    ]
+
+    operations = [
+        # Step 1: Add reference_id CharField to Reference (nullable temporarily)
+        migrations.AddField(
+            model_name='reference',
+            name='reference_id',
+            field=models.CharField(
+                max_length=255,
+                null=True,
+                unique=True,
+                verbose_name='reference id',
+                help_text='Unique identifier for the reference.',
+            ),
+        ),
+        # Step 2: Add temporary FK on Experiment pointing to Reference via reference_id
+        migrations.AddField(
+            model_name='experiment',
+            name='reference_new',
+            field=models.ForeignKey(
+                help_text='Temporary reference field for migration purposes',
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='+',
+                to='ned_app.reference',
+                to_field='reference_id',
+            ),
+        ),
+        # Step 3: Add temporary FK on FragilityCurve pointing to Reference via reference_id
+        migrations.AddField(
+            model_name='fragilitycurve',
+            name='reference_new',
+            field=models.ForeignKey(
+                help_text='Temporary reference field for migration purposes',
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='+',
+                to='ned_app.reference',
+                to_field='reference_id',
+            ),
+        ),
+    ]

--- a/ned_app/migrations/0019_populate_reference_id_and_copy_fks.py
+++ b/ned_app/migrations/0019_populate_reference_id_and_copy_fks.py
@@ -1,0 +1,60 @@
+from django.db import migrations
+
+
+def populate_reference_id_and_copy_fks(apps, schema_editor):
+    """
+    Copy Reference.id -> Reference.reference_id, then copy FK links
+    from Experiment.reference and FragilityCurve.reference to their
+    respective _new fields.
+    """
+    Reference = apps.get_model('ned_app', 'Reference')
+    Experiment = apps.get_model('ned_app', 'Experiment')
+    FragilityCurve = apps.get_model('ned_app', 'FragilityCurve')
+
+    # Step 1: Populate reference_id from id on all References
+    references = Reference.objects.all()
+    ref_count = references.count()
+    for ref in references:
+        ref.reference_id = ref.id
+        ref.save()
+
+    populated_count = Reference.objects.filter(reference_id__isnull=False).count()
+    assert populated_count == ref_count, (
+        f'Expected {ref_count} references with reference_id, got {populated_count}'
+    )
+
+    # Step 2: Copy Experiment.reference -> Experiment.reference_new
+    experiments = Experiment.objects.all()
+    exp_count = experiments.count()
+    for exp in experiments:
+        exp.reference_new = exp.reference
+        exp.save()
+
+    exp_populated = Experiment.objects.filter(reference_new__isnull=False).count()
+    assert exp_populated == exp_count, (
+        f'Expected {exp_count} experiments with reference_new, got {exp_populated}'
+    )
+
+    # Step 3: Copy FragilityCurve.reference -> FragilityCurve.reference_new
+    curves = FragilityCurve.objects.all()
+    curve_count = curves.count()
+    for curve in curves:
+        curve.reference_new = curve.reference
+        curve.save()
+
+    curve_populated = FragilityCurve.objects.filter(
+        reference_new__isnull=False
+    ).count()
+    assert curve_populated == curve_count, (
+        f'Expected {curve_count} curves with reference_new, got {curve_populated}'
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('ned_app', '0018_reference_add_reference_id_and_temp_fks'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_reference_id_and_copy_fks),
+    ]

--- a/ned_app/migrations/0020_swap_reference_pk.py
+++ b/ned_app/migrations/0020_swap_reference_pk.py
@@ -1,0 +1,79 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('ned_app', '0019_populate_reference_id_and_copy_fks'),
+    ]
+
+    operations = [
+        # Step 1: Remove old reference FKs (pointing to Reference.id CharField PK)
+        migrations.RemoveField(
+            model_name='experiment',
+            name='reference',
+        ),
+        migrations.RemoveField(
+            model_name='fragilitycurve',
+            name='reference',
+        ),
+        # Step 2: Rename temporary FKs to final names
+        migrations.RenameField(
+            model_name='experiment',
+            old_name='reference_new',
+            new_name='reference',
+        ),
+        migrations.RenameField(
+            model_name='fragilitycurve',
+            old_name='reference_new',
+            new_name='reference',
+        ),
+        # Step 3: Remove old CharField PK from Reference
+        migrations.RemoveField(
+            model_name='reference',
+            name='id',
+        ),
+        # Step 4: Add BigAutoField PK to Reference
+        migrations.AddField(
+            model_name='reference',
+            name='id',
+            field=models.BigAutoField(
+                auto_created=True,
+                primary_key=True,
+                serialize=False,
+                verbose_name='ID',
+            ),
+        ),
+        # Step 5: Make reference_id non-nullable
+        migrations.AlterField(
+            model_name='reference',
+            name='reference_id',
+            field=models.CharField(
+                max_length=255,
+                unique=True,
+                verbose_name='reference id',
+                help_text='Unique identifier for the reference.',
+            ),
+        ),
+        # Step 6: Enforce non-null on renamed FK fields
+        migrations.AlterField(
+            model_name='experiment',
+            name='reference',
+            field=models.ForeignKey(
+                help_text='ID of the published reference documenting this experimental observation.',
+                on_delete=django.db.models.deletion.PROTECT,
+                to='ned_app.reference',
+                to_field='reference_id',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='fragilitycurve',
+            name='reference',
+            field=models.ForeignKey(
+                help_text='ID of the published reference documenting this fragility curve.',
+                on_delete=django.db.models.deletion.PROTECT,
+                to='ned_app.reference',
+                to_field='reference_id',
+            ),
+        ),
+    ]

--- a/ned_app/models.py
+++ b/ned_app/models.py
@@ -58,7 +58,12 @@ class Reference(models.Model):
         LIT_REVIEW = 'Lit Review'
         OTHER = 'Other'
 
-    id = models.CharField(_('id'), primary_key=True, max_length=255)
+    reference_id = models.CharField(
+        _('reference id'),
+        max_length=255,
+        unique=True,
+        help_text='Unique identifier for the reference.',
+    )
     title = models.CharField(
         _('title'),
         max_length=255,
@@ -112,7 +117,7 @@ class Reference(models.Model):
         verbose_name_plural = 'References'
 
     def __str__(self):
-        return self.title
+        return self.reference_id
 
     def save(self, *args, **kwargs):
         """
@@ -274,6 +279,7 @@ class Experiment(models.Model):
     reference = models.ForeignKey(
         'Reference',
         on_delete=models.PROTECT,
+        to_field='reference_id',
         help_text='ID of the published reference documenting this experimental observation.',
     )
     specimen = models.CharField(
@@ -630,6 +636,7 @@ class FragilityCurve(models.Model):
     reference = models.ForeignKey(
         'Reference',
         on_delete=models.PROTECT,
+        to_field='reference_id',
         help_text='ID of the published reference documenting.',
     )
     edp_metric = models.CharField(

--- a/ned_app/serialization/serializer.py
+++ b/ned_app/serialization/serializer.py
@@ -31,7 +31,7 @@ class ReferenceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Reference
         fields = [
-            'id',
+            'reference_id',
             'title',
             'author',
             'year',
@@ -158,11 +158,11 @@ class ExperimentSerializer(serializers.ModelSerializer):
     """
     Serializer for Experiment with reference and component relationships.
 
-    Uses natural keys for foreign key lookups: reference.id and component.component_id.
+    Uses natural keys for foreign key lookups: reference.reference_id and component.component_id.
     """
 
     reference = serializers.SlugRelatedField(
-        slug_field='id', queryset=Reference.objects.all()
+        slug_field='reference_id', queryset=Reference.objects.all()
     )
     component = serializers.SlugRelatedField(
         slug_field='component_id', queryset=Component.objects.all()
@@ -259,7 +259,7 @@ class FragilityCurveSerializer(serializers.ModelSerializer):
         slug_field='id', queryset=FragilityModel.objects.all()
     )
     reference = serializers.SlugRelatedField(
-        slug_field='id', queryset=Reference.objects.all()
+        slug_field='reference_id', queryset=Reference.objects.all()
     )
 
     class Meta:

--- a/ned_app/tests/management/test_export_data_command.py
+++ b/ned_app/tests/management/test_export_data_command.py
@@ -27,7 +27,7 @@ class ExportDataCommandTest(TestCase):
         )
 
         self.reference = Reference.objects.create(
-            id='test-ref-001',
+            reference_id='test-ref-001',
             study_type='Experiment',
             comp_type='Test Component Type',
             pdf_saved=True,
@@ -149,7 +149,7 @@ class ExportDataCommandTest(TestCase):
             self.assertEqual(len(reference_data), 1)
             ref_data = reference_data[0]
 
-            self.assertEqual(ref_data['id'], 'test-ref-001')
+            self.assertEqual(ref_data['reference_id'], 'test-ref-001')
             self.assertIn('study_type', ref_data)
             self.assertEqual(ref_data['study_type'], 'Experiment')
             self.assertIn('comp_type', ref_data)

--- a/ned_app/tests/management/test_ingest_command.py
+++ b/ned_app/tests/management/test_ingest_command.py
@@ -29,7 +29,7 @@ class IngestCommandTests(TransactionTestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             reference_data = [
                 {
-                    'id': 'ref-001',
+                    'reference_id': 'ref-001',
                     'study_type': 'Experiment',
                     'comp_type': 'Structural Component',
                     'pdf_saved': True,
@@ -42,7 +42,7 @@ class IngestCommandTests(TransactionTestCase):
                     },
                 },
                 {
-                    'id': 'ref-002',
+                    'reference_id': 'ref-002',
                     'study_type': 'Analytical Study',
                     'comp_type': 'Mechanical Component',
                     'pdf_saved': False,
@@ -219,11 +219,11 @@ class IngestCommandTests(TransactionTestCase):
             self.assertEqual(FragilityCurve.objects.count(), 3)
 
             exp_001 = Experiment.objects.get(id='exp-001')
-            self.assertEqual(exp_001.reference.id, 'ref-001')
+            self.assertEqual(exp_001.reference.reference_id, 'ref-001')
             self.assertEqual(exp_001.component.component_id, 'B.20.1.1.A')
 
             exp_002 = Experiment.objects.get(id='exp-002')
-            self.assertEqual(exp_002.reference.id, 'ref-001')
+            self.assertEqual(exp_002.reference.reference_id, 'ref-001')
             self.assertEqual(exp_002.component.component_id, 'D.30.3.2.B')
 
             cfm_bridge_1 = ComponentFragilityModelBridge.objects.get(
@@ -256,19 +256,19 @@ class IngestCommandTests(TransactionTestCase):
                 fragility_model__id='fm-001', ds_rank=1
             )
             self.assertEqual(fc_1.fragility_model.id, 'fm-001')
-            self.assertEqual(fc_1.reference.id, 'ref-001')
+            self.assertEqual(fc_1.reference.reference_id, 'ref-001')
 
             fc_2 = FragilityCurve.objects.get(
                 fragility_model__id='fm-001', ds_rank=2
             )
             self.assertEqual(fc_2.fragility_model.id, 'fm-001')
-            self.assertEqual(fc_2.reference.id, 'ref-002')
+            self.assertEqual(fc_2.reference.reference_id, 'ref-002')
 
             fc_3 = FragilityCurve.objects.get(
                 fragility_model__id='fm-002', ds_rank=1
             )
             self.assertEqual(fc_3.fragility_model.id, 'fm-002')
-            self.assertEqual(fc_3.reference.id, 'ref-002')
+            self.assertEqual(fc_3.reference.reference_id, 'ref-002')
 
     def test_ingest_component_id_generation(self):
         """Test that Component id field is auto-generated from component_id."""
@@ -302,7 +302,7 @@ class IngestCommandTests(TransactionTestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             reference_data = [
                 {
-                    'id': 'ref-001',
+                    'reference_id': 'ref-001',
                     'study_type': 'Experiment',
                     'comp_type': 'Structural Component',
                     'pdf_saved': True,
@@ -329,7 +329,7 @@ class IngestCommandTests(TransactionTestCase):
             ):
                 call_command('ingest')
 
-            reference = Reference.objects.get(id='ref-001')
+            reference = Reference.objects.get(reference_id='ref-001')
 
             self.assertEqual(
                 reference.title, 'Experimental Study of Building Components'
@@ -342,7 +342,7 @@ class IngestCommandTests(TransactionTestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             reference_data = [
                 {
-                    'id': 'ref-001',
+                    'reference_id': 'ref-001',
                     'study_type': 'Experiment',
                     'comp_type': 'Structural Component',
                     'pdf_saved': True,
@@ -427,7 +427,7 @@ class IngestCommandTests(TransactionTestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             reference_data = [
                 {
-                    'id': 'ref-001',
+                    'reference_id': 'ref-001',
                     'study_type': 'Experiment',
                     'comp_type': 'Structural Component',
                     'pdf_saved': True,
@@ -440,7 +440,7 @@ class IngestCommandTests(TransactionTestCase):
                     },
                 },
                 {
-                    'id': 'ref-002',
+                    'reference_id': 'ref-002',
                     'study_type': 'Analytical Study',
                     'comp_type': 'Mechanical Component',
                     'pdf_saved': False,
@@ -475,8 +475,12 @@ class IngestCommandTests(TransactionTestCase):
             self.assertIn('ref-002', stderr_value)
 
             self.assertEqual(Reference.objects.count(), 1)
-            self.assertTrue(Reference.objects.filter(id='ref-001').exists())
-            self.assertFalse(Reference.objects.filter(id='ref-002').exists())
+            self.assertTrue(
+                Reference.objects.filter(reference_id='ref-001').exists()
+            )
+            self.assertFalse(
+                Reference.objects.filter(reference_id='ref-002').exists()
+            )
 
     def test_ingest_handles_invalid_foreign_key(self):
         """Test that the command handles invalid foreign key references gracefully."""
@@ -542,7 +546,7 @@ class IngestCommandTests(TransactionTestCase):
             # --- 1. Initial Data Setup ---
             reference_data = [
                 {
-                    'id': 'ref-idem',
+                    'reference_id': 'ref-idem',
                     'study_type': 'Experiment',
                     'csl_data': {
                         'type': 'article-journal',
@@ -633,7 +637,7 @@ class IngestCommandTests(TransactionTestCase):
                 self.assertEqual(ExperimentFragilityModelBridge.objects.count(), 1)
                 self.assertEqual(FragilityCurve.objects.count(), 1)
 
-                ref = Reference.objects.get(id='ref-idem')
+                ref = Reference.objects.get(reference_id='ref-idem')
                 self.assertEqual(ref.title, 'Original Title')
 
                 comp = Component.objects.get(component_id='A.10.1.1')
@@ -690,7 +694,7 @@ class IngestCommandTests(TransactionTestCase):
                 self.assertEqual(FragilityCurve.objects.count(), 1)
 
                 # --- 6. Verify Updates in Database ---
-                ref = Reference.objects.get(id='ref-idem')
+                ref = Reference.objects.get(reference_id='ref-idem')
                 ref.refresh_from_db()
                 self.assertEqual(ref.title, 'Updated Title')
 

--- a/ned_app/tests/serialization/test_serializers.py
+++ b/ned_app/tests/serialization/test_serializers.py
@@ -41,7 +41,7 @@ class ReferenceSerializerTest(TestCase):
         }
 
         self.valid_reference_data = {
-            'id': 'test-serializer-001',
+            'reference_id': 'test-serializer-001',
             'csl_data': self.valid_csl_data,
             'study_type': 'Experiment',
             'comp_type': 'Test Component',
@@ -143,7 +143,7 @@ class ReferenceSerializerTest(TestCase):
                 reference = serializer.save()
 
                 self.assertIsInstance(reference, Reference)
-                self.assertEqual(reference.id, 'test-serializer-001')
+                self.assertEqual(reference.reference_id, 'test-serializer-001')
                 self.assertEqual(reference.csl_data, self.valid_csl_data)
 
                 self.assertEqual(reference.title, 'Test Article for Serializer')
@@ -153,7 +153,7 @@ class ReferenceSerializerTest(TestCase):
     def test_serializer_handles_optional_fields(self):
         """Test that serializer handles optional auto-populated fields correctly."""
         minimal_data = {
-            'id': 'test-serializer-002',
+            'reference_id': 'test-serializer-002',
             'csl_data': {
                 'type': 'article-journal',
                 'id': 'test-serializer-002',
@@ -216,7 +216,7 @@ class ReferenceSerializerTest(TestCase):
         }
 
         complex_data = {
-            'id': 'test-complex-001',
+            'reference_id': 'test-complex-001',
             'csl_data': complex_csl_data,
             'study_type': 'Experiment',
         }
@@ -346,7 +346,7 @@ class ReferenceSerializerTest(TestCase):
 
     def tearDown(self):
         """Clean up test data after each test."""
-        Reference.objects.filter(id__startswith='test-').delete()
+        Reference.objects.filter(reference_id__startswith='test-').delete()
 
 
 class ComponentSerializerTest(TestCase):
@@ -457,7 +457,7 @@ class ExperimentSerializerTest(TestCase):
         )
 
         self.reference = Reference.objects.create(
-            id='test-ref-001',
+            reference_id='test-ref-001',
             csl_data={
                 'type': 'article-journal',
                 'id': 'test-ref-001',
@@ -488,7 +488,7 @@ class ExperimentSerializerTest(TestCase):
 
         self.assertIsNotNone(experiment)
         self.assertEqual(experiment.id, 'test-exp-001')
-        self.assertEqual(experiment.reference.id, 'test-ref-001')
+        self.assertEqual(experiment.reference.reference_id, 'test-ref-001')
         self.assertEqual(experiment.component.component_id, 'A.10.1.1')
 
     def test_serializer_rejects_nonexistent_reference(self):
@@ -520,7 +520,7 @@ class ExperimentSerializerTest(TestCase):
     def tearDown(self):
         """Clean up test data after each test."""
         Experiment.objects.filter(id__startswith='test-exp-').delete()
-        Reference.objects.filter(id__startswith='test-ref-').delete()
+        Reference.objects.filter(reference_id__startswith='test-ref-').delete()
         Component.objects.filter(component_id='A.10.1.1').delete()
 
 
@@ -535,7 +535,7 @@ class ExperimentFragilityModelBridgeSerializerTest(TestCase):
         )
 
         self.reference = Reference.objects.create(
-            id='test-ref-001',
+            reference_id='test-ref-001',
             csl_data={
                 'type': 'article-journal',
                 'id': 'test-ref-001',
@@ -601,7 +601,7 @@ class ExperimentFragilityModelBridgeSerializerTest(TestCase):
         ExperimentFragilityModelBridge.objects.all().delete()
         FragilityModel.objects.filter(id__startswith='test-fm-').delete()
         Experiment.objects.filter(id__startswith='test-exp-').delete()
-        Reference.objects.filter(id__startswith='test-ref-').delete()
+        Reference.objects.filter(reference_id__startswith='test-ref-').delete()
         Component.objects.filter(component_id='A.10.1.1').delete()
 
 
@@ -673,7 +673,7 @@ class FragilityCurveSerializerTest(TestCase):
     def setUp(self):
         """Set up test data."""
         self.reference = Reference.objects.create(
-            id='test-ref-001',
+            reference_id='test-ref-001',
             csl_data={
                 'type': 'article-journal',
                 'id': 'test-ref-001',
@@ -708,7 +708,7 @@ class FragilityCurveSerializerTest(TestCase):
 
         self.assertIsNotNone(fragility_curve)
         self.assertEqual(fragility_curve.fragility_model.id, 'test-fm-001')
-        self.assertEqual(fragility_curve.reference.id, 'test-ref-001')
+        self.assertEqual(fragility_curve.reference.reference_id, 'test-ref-001')
 
     def test_serializer_rejects_nonexistent_fragility_model(self):
         """Test that serializer rejects data with a non-existent fragility_model ID."""
@@ -750,4 +750,4 @@ class FragilityCurveSerializerTest(TestCase):
         """Clean up test data after each test."""
         FragilityCurve.objects.all().delete()
         FragilityModel.objects.filter(id__startswith='test-fm-').delete()
-        Reference.objects.filter(id__startswith='test-ref-').delete()
+        Reference.objects.filter(reference_id__startswith='test-ref-').delete()

--- a/ned_app/tests/test_data_integrity.py
+++ b/ned_app/tests/test_data_integrity.py
@@ -146,7 +146,7 @@ class DataIntegrityTests(TransactionTestCase):
             # Map each JSON file to its sort key function
             # For tables with composite keys, use tuple sorting
             json_files = {
-                'reference.json': lambda x: x['id'],
+                'reference.json': lambda x: x['reference_id'],
                 'component.json': lambda x: x['component_id'],
                 'fragility_model.json': lambda x: x['id'],
                 'experiment.json': lambda x: x['id'],

--- a/ned_app/tests/test_data_integrity.py
+++ b/ned_app/tests/test_data_integrity.py
@@ -150,6 +150,10 @@ class DataIntegrityTests(TransactionTestCase):
                 'component.json': lambda x: x['component_id'],
                 'fragility_model.json': lambda x: x['id'],
                 'experiment.json': lambda x: x['id'],
+                'component_fragility_model_bridge.json': lambda x: (
+                    x['component'],
+                    x['fragility_model'],
+                ),
                 'experiment_fragility_model_bridge.json': lambda x: (
                     x['experiment'],
                     x['fragility_model'],

--- a/ned_app/tests/test_models.py
+++ b/ned_app/tests/test_models.py
@@ -16,7 +16,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-001', csl_data=csl_data)
+        ref = Reference(reference_id='test-001', csl_data=csl_data)
         ref.save()
 
         self.assertEqual(ref.title, 'Test Article Title')
@@ -31,7 +31,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2022]]},
         }
 
-        ref = Reference(id='test-002', csl_data=csl_data)
+        ref = Reference(reference_id='test-002', csl_data=csl_data)
         ref.save()
 
         self.assertEqual(ref.year, 2022)
@@ -46,7 +46,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-003', csl_data=csl_data)
+        ref = Reference(reference_id='test-003', csl_data=csl_data)
         ref.save()
 
         self.assertEqual(ref.author, 'Johnson')
@@ -64,7 +64,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-004', csl_data=csl_data)
+        ref = Reference(reference_id='test-004', csl_data=csl_data)
         ref.save()
 
         self.assertEqual(ref.author, 'Smith and Doe')
@@ -84,7 +84,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-005', csl_data=csl_data)
+        ref = Reference(reference_id='test-005', csl_data=csl_data)
         ref.save()
 
         self.assertEqual(ref.author, 'Smith et al.')
@@ -99,7 +99,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-006', csl_data=csl_data)
+        ref = Reference(reference_id='test-006', csl_data=csl_data)
         ref.save()
 
         # Should extract last word from literal name
@@ -119,7 +119,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-007', csl_data=csl_data)
+        ref = Reference(reference_id='test-007', csl_data=csl_data)
         ref.save()
 
         # Should use "et al." for 3+ authors
@@ -127,7 +127,7 @@ class ReferenceModelTest(TestCase):
 
     def test_save_handles_missing_csl_data(self):
         """Test that save() raises ValidationError for missing csl_data."""
-        ref = Reference(id='test-008')
+        ref = Reference(reference_id='test-008')
 
         with self.assertRaises(ValidationError) as context:
             ref.save()
@@ -138,7 +138,7 @@ class ReferenceModelTest(TestCase):
 
     def test_save_handles_empty_csl_data(self):
         """Test that save() raises ValidationError for empty csl_data."""
-        ref = Reference(id='test-009', csl_data={})
+        ref = Reference(reference_id='test-009', csl_data={})
 
         with self.assertRaises(ValidationError) as context:
             ref.save()
@@ -156,7 +156,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-010', csl_data=csl_data)
+        ref = Reference(reference_id='test-010', csl_data=csl_data)
 
         with self.assertRaises(ValidationError) as context:
             ref.save()
@@ -174,7 +174,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-011', csl_data=csl_data)
+        ref = Reference(reference_id='test-011', csl_data=csl_data)
 
         with self.assertRaises(ValidationError) as context:
             ref.save()
@@ -194,7 +194,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-012', csl_data=csl_data)
+        ref = Reference(reference_id='test-012', csl_data=csl_data)
 
         with self.assertRaises(ValidationError) as context:
             ref.save()
@@ -214,7 +214,7 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[]]},  # Empty date parts
         }
 
-        ref = Reference(id='test-013', csl_data=csl_data)
+        ref = Reference(reference_id='test-013', csl_data=csl_data)
 
         with self.assertRaises(ValidationError) as context:
             ref.save()
@@ -233,7 +233,7 @@ class ReferenceModelTest(TestCase):
             'author': [{'family': 'Smith', 'given': 'John'}],
         }
 
-        ref = Reference(id='test-014', csl_data=csl_data)
+        ref = Reference(reference_id='test-014', csl_data=csl_data)
 
         with self.assertRaises(ValidationError) as context:
             ref.save()
@@ -255,14 +255,14 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-015', csl_data=csl_data)
+        ref = Reference(reference_id='test-015', csl_data=csl_data)
         ref.save()
 
         # Should only use authors with family names
         self.assertEqual(ref.author, 'Smith')
 
-    def test_str_method_returns_title(self):
-        """Test that __str__ method returns the title field."""
+    def test_str_method_returns_reference_id(self):
+        """Test that __str__ method returns the reference_id field."""
         csl_data = {
             'type': 'article-journal',
             'id': 'test-016',
@@ -271,14 +271,14 @@ class ReferenceModelTest(TestCase):
             'issued': {'date-parts': [[2023]]},
         }
 
-        ref = Reference(id='test-016', csl_data=csl_data)
+        ref = Reference(reference_id='test-016', csl_data=csl_data)
         ref.save()
 
-        self.assertEqual(str(ref), 'Test String Representation')
+        self.assertEqual(str(ref), 'test-016')
 
     def tearDown(self):
         """Clean up test data after each test."""
-        Reference.objects.filter(id__startswith='test-').delete()
+        Reference.objects.filter(reference_id__startswith='test-').delete()
 
 
 class ComponentModelTest(TestCase):

--- a/resources/data/reference.json
+++ b/resources/data/reference.json
@@ -33,8 +33,8 @@
             "title": "Experimental and Analytical Studies of Hospital Piping Assemblies Subjected to Seismic Loading",
             "type": "document"
         },
-        "id": "ARA-2012-EXP",
         "pdf_saved": true,
+        "reference_id": "ARA-2012-EXP",
         "study_type": "Experiment"
     },
     {
@@ -64,8 +64,8 @@
             "title": "Novel Sliding/frictional Connections for Improved Seismic Performance of Gypsum Wallboard Partitions",
             "type": "paper-conference"
         },
-        "id": "ARA-2012-NOV",
         "pdf_saved": true,
+        "reference_id": "ARA-2012-NOV",
         "study_type": "Experiment"
     },
     {
@@ -110,8 +110,8 @@
             "title": "Experimental Evaluation of the Seismic Response of a Rooftop_x0002_-Mounted Cooling Tower",
             "type": "document"
         },
-        "id": "AST-2015-EXP",
         "pdf_saved": true,
+        "reference_id": "AST-2015-EXP",
         "study_type": "Experiment"
     },
     {
@@ -136,8 +136,8 @@
             "title": "Seismic Performance of Precast Concrete Cladding Systems (PhD Thesis)",
             "type": "document"
         },
-        "id": "BAI-2014-SEI",
         "pdf_saved": true,
+        "reference_id": "BAI-2014-SEI",
         "study_type": "Experiment"
     },
     {
@@ -166,8 +166,8 @@
             "title": "Seismic fragility of threaded Tee-joint connections in piping systems",
             "type": "document"
         },
-        "id": "BUS-2015-SEI",
         "pdf_saved": true,
+        "reference_id": "BUS-2015-SEI",
         "study_type": "Experiment"
     },
     {
@@ -204,8 +204,8 @@
             "title": "Experimental Fragility Analysis of Pressurized Fire Sprinkler Piping Systems",
             "type": "document"
         },
-        "id": "CRA-2016-EXP",
         "pdf_saved": true,
+        "reference_id": "CRA-2016-EXP",
         "study_type": "Experiment"
     },
     {
@@ -242,8 +242,8 @@
             "title": "Out-of-Plane Seismic Performance of Plasterboard Partition Walls via Quasi-Static Tests",
             "type": "article-journal"
         },
-        "id": "CRE-2016-OUT",
         "pdf_saved": true,
+        "reference_id": "CRE-2016-OUT",
         "study_type": "Experiment"
     },
     {
@@ -287,8 +287,8 @@
             "title": "Experimental Seismic Evaluation, Model Parameterization and Effects of Cold-Formed Steel-Framed Gypsum Partition Walls on the Seismic Performance of an Essential Facility",
             "type": "report"
         },
-        "id": "DAV-2011-EXP",
         "pdf_saved": true,
+        "reference_id": "DAV-2011-EXP",
         "study_type": "Experiment"
     },
     {
@@ -313,8 +313,8 @@
             "title": "Seismic Capacity of Threaded, Brazed and Grooved Clamped Joints",
             "type": "document"
         },
-        "id": "GEO-2004-SEI",
         "pdf_saved": true,
+        "reference_id": "GEO-2004-SEI",
         "study_type": "Experiment"
     },
     {
@@ -351,8 +351,8 @@
             "title": "Seismic response evaluation of medical gas and fire-protection pipelines\u2019 Tee-Joints",
             "type": "document"
         },
-        "id": "GIA-2018-SEI",
         "pdf_saved": true,
+        "reference_id": "GIA-2018-SEI",
         "study_type": "Experiment"
     },
     {
@@ -378,8 +378,8 @@
             "title": "Experimental Evaluation of the Seismic Performance of Hospital Piping Subassemblies",
             "type": "thesis"
         },
-        "id": "GOO-2004-EXP",
         "pdf_saved": true,
+        "reference_id": "GOO-2004-EXP",
         "study_type": "Experiment"
     },
     {
@@ -420,8 +420,8 @@
             "title": "Cyclic tests of steel tee energy absorbers for precast exterior wall panels in steel building frames",
             "type": "article-journal"
         },
-        "id": "HET-2021-CYC",
         "pdf_saved": true,
+        "reference_id": "HET-2021-CYC",
         "study_type": "Experiment"
     },
     {
@@ -446,8 +446,8 @@
             "title": "Prefabricated Steel Stair Performance under Combined Seismic and Gravity Loads",
             "type": "document"
         },
-        "id": "HIG-2009-PRE",
         "pdf_saved": true,
+        "reference_id": "HIG-2009-PRE",
         "study_type": "Experiment"
     },
     {
@@ -492,8 +492,8 @@
             "title": "Theoretical and experimental evaluation of timber-framed partitions under lateral drift.",
             "type": "article-journal"
         },
-        "id": "JIT-2021-THE",
         "pdf_saved": true,
+        "reference_id": "JIT-2021-THE",
         "study_type": "Experiment"
     },
     {
@@ -526,8 +526,8 @@
             "title": "Cyclic Behaviour of Two-Story Low-Damage Rocking Precast Concrete Cladding Panel System",
             "type": "article-journal"
         },
-        "id": "JIT-2022-CYC",
         "pdf_saved": true,
+        "reference_id": "JIT-2022-CYC",
         "study_type": "Experiment"
     },
     {
@@ -564,8 +564,8 @@
             "title": "Low-Damage Rocking Precast Concrete Cladding Panels: Design\nApproach and Experimental Validation",
             "type": "article-journal"
         },
-        "id": "JIT-2022-LOW",
         "pdf_saved": true,
+        "reference_id": "JIT-2022-LOW",
         "study_type": "Experiment"
     },
     {
@@ -598,8 +598,8 @@
             "title": "Seismic Performance of a Rocking Precast Concrete Cladding Panel System under Lateral Cyclic Displacement Demands",
             "type": "article-journal"
         },
-        "id": "JIT-2022-SEI",
         "pdf_saved": true,
+        "reference_id": "JIT-2022-SEI",
         "study_type": "Experiment"
     },
     {
@@ -632,8 +632,8 @@
             "title": "Seismic Evaluation of Rocking Internal Partition Walls with Dual-Slot Track Under Quasi-Static Cyclic Drifts",
             "type": "article-journal"
         },
-        "id": "JIT-2023-SEI",
         "pdf_saved": true,
+        "reference_id": "JIT-2023-SEI",
         "study_type": "Experiment"
     },
     {
@@ -666,8 +666,8 @@
             "title": "Seismic Performance of \u2018Rocking\u2019 Dual-slot Track Internal Partition Walls with Concealed Joints under Lateral Cyclic Drift Demands",
             "type": "article-journal"
         },
-        "id": "JIT-2023-SEI-2",
         "pdf_saved": true,
+        "reference_id": "JIT-2023-SEI-2",
         "study_type": "Experiment"
     },
     {
@@ -708,8 +708,8 @@
             "title": "Seismic Performance of Internal Partition Walls with Slotted and Bracketed Head-Tracks",
             "type": "article-journal"
         },
-        "id": "JIT-2023-SEI-3",
         "pdf_saved": true,
+        "reference_id": "JIT-2023-SEI-3",
         "study_type": "Experiment"
     },
     {
@@ -758,8 +758,8 @@
             "title": "Response of Exterior Precast Concrete Cladding Panels in NEES-TIPS/NEES-GC/E-Defense Tests on a Full Scale 5-story Building",
             "type": "article-journal"
         },
-        "id": "KUR-2012-RES",
         "pdf_saved": true,
+        "reference_id": "KUR-2012-RES",
         "study_type": "Experiment"
     },
     {
@@ -800,8 +800,8 @@
             "title": "Seismic Performance Evaluation of Nonstructural Components: Drywall Partitions",
             "type": "document"
         },
-        "id": "LEE-2007-SEI",
         "pdf_saved": true,
+        "reference_id": "LEE-2007-SEI",
         "study_type": "Experiment"
     },
     {
@@ -830,8 +830,8 @@
             "title": "Seismic Performance of Gypsum Walls: Experimental Test Program",
             "type": "report"
         },
-        "id": "MCM-2002-SEI",
         "pdf_saved": true,
+        "reference_id": "MCM-2002-SEI",
         "study_type": "Experiment"
     },
     {
@@ -856,8 +856,8 @@
             "title": "Seismic assessment and design of fire sprinkler piping systems",
             "type": "document"
         },
-        "id": "MUH-2022-SEI",
         "pdf_saved": true,
+        "reference_id": "MUH-2022-SEI",
         "study_type": "Experiment"
     },
     {
@@ -883,8 +883,8 @@
             "title": "Seismic Behavior of Architectural Precast Concrete Cladding Panels and Connections",
             "type": "thesis"
         },
-        "id": "PAN-2016-SEI",
         "pdf_saved": true,
+        "reference_id": "PAN-2016-SEI",
         "study_type": "Experiment"
     },
     {
@@ -914,8 +914,8 @@
             "title": "Seismic response of ceiling/piping/partition systems in NEESR-GC system-level experiments",
             "type": "paper-conference"
         },
-        "id": "RAH-2014-SEI",
         "pdf_saved": true,
+        "reference_id": "RAH-2014-SEI",
         "study_type": "Analytical Study"
     },
     {
@@ -945,8 +945,8 @@
             "title": "Seismic Response of Ceiling/Piping/Partition Systems in NEESR-GC System-Level Experiments",
             "type": "paper-conference"
         },
-        "id": "RAH-2014-SYS",
         "pdf_saved": true,
+        "reference_id": "RAH-2014-SYS",
         "study_type": "Experiment"
     },
     {
@@ -975,8 +975,8 @@
             "title": "Performance Characteristics of Light Gage Steel Stud Partition Walls",
             "type": "document"
         },
-        "id": "RES-2011-PER",
         "pdf_saved": true,
+        "reference_id": "RES-2011-PER",
         "study_type": "Experiment"
     },
     {
@@ -1021,8 +1021,8 @@
             "title": "Seismic Simulation of an Integrated Ceiling-Partition Wall-Piping System at E-Defense. I: Three-Dimensional Structural Response and Base Isolation",
             "type": "document"
         },
-        "id": "RYA-2015-SEI",
         "pdf_saved": true,
+        "reference_id": "RYA-2015-SEI",
         "study_type": "Experiment"
     },
     {
@@ -1060,8 +1060,8 @@
             "title": "Full Scale Dynamic Testing of Large Area Suspended Ceiling System",
             "type": "paper-conference"
         },
-        "id": "RYU-2012-FUL",
         "pdf_saved": true,
+        "reference_id": "RYU-2012-FUL",
         "study_type": "Experiment"
     },
     {
@@ -1090,8 +1090,8 @@
             "title": "Experimental Study of Large Area Suspended Ceilings",
             "type": "article-journal"
         },
-        "id": "RYU-2019-EXP",
         "pdf_saved": true,
+        "reference_id": "RYU-2019-EXP",
         "study_type": "Experiment"
     },
     {
@@ -1117,8 +1117,8 @@
             "title": "Analytical Seismic Fragility of Fire Sprinkler Piping Systems",
             "type": "thesis"
         },
-        "id": "SOR-2013-ANA",
         "pdf_saved": true,
+        "reference_id": "SOR-2013-ANA",
         "study_type": "Experiment"
     },
     {
@@ -1155,8 +1155,8 @@
             "title": "Fragility Analysis of Suspended Ceiling Systems in a Full-Scale Experiment",
             "type": "article-journal"
         },
-        "id": "SOR-2018-FRA",
         "pdf_saved": true,
+        "reference_id": "SOR-2018-FRA",
         "study_type": "Experiment"
     },
     {
@@ -1193,8 +1193,8 @@
             "title": "Seismic behavior of riser pipes with pressure and groove joints using an in-plane cyclic loading test",
             "type": "document"
         },
-        "id": "SUN-2021-SEI",
         "pdf_saved": true,
+        "reference_id": "SUN-2021-SEI",
         "study_type": "Experiment"
     },
     {
@@ -1231,8 +1231,8 @@
             "title": "Experiments and Fragility Analyses of Piping Systems Connected by Grooved Fit Joints With Large Deformability",
             "type": "document"
         },
-        "id": "TAO-2019-EXP",
         "pdf_saved": true,
+        "reference_id": "TAO-2019-EXP",
         "study_type": "Experiment"
     },
     {
@@ -1257,8 +1257,8 @@
             "title": "Damage Mitigation Strategies for Non-Structural Infill Walls (PhD Thesis)",
             "type": "document"
         },
-        "id": "TAS-2014-DAM",
         "pdf_saved": true,
+        "reference_id": "TAS-2014-DAM",
         "study_type": "Experiment"
     },
     {
@@ -1303,8 +1303,8 @@
             "title": "In\u2010plane quasi\u2010static cyclic tests of nonstructural\nlightweight steel drywall partitions for seismic performance\nevaluation",
             "type": "article-journal"
         },
-        "id": "TAT-2018-INP",
         "pdf_saved": true,
+        "reference_id": "TAT-2018-INP",
         "study_type": "Experiment"
     },
     {
@@ -1353,8 +1353,8 @@
             "title": "Shake table testing of an elevator system in a full-scale five-story building",
             "type": "article-journal"
         },
-        "id": "WAN-2016-SHA",
         "pdf_saved": true,
+        "reference_id": "WAN-2016-SHA",
         "study_type": "Experiment"
     },
     {
@@ -1387,8 +1387,8 @@
             "title": "Seismic Response of Pressurized Fire Sprinkler Piping Systems I: Experimental Study",
             "type": "document"
         },
-        "id": "YUA-2015-SEI",
         "pdf_saved": true,
+        "reference_id": "YUA-2015-SEI",
         "study_type": "Experiment"
     },
     {
@@ -1425,8 +1425,8 @@
             "title": "Experimental Studies of a Typical Sprinkler Piping System in Hospitals",
             "type": "document"
         },
-        "id": "ZHE-2016-EXP",
         "pdf_saved": true,
+        "reference_id": "ZHE-2016-EXP",
         "study_type": "Experiment"
     },
     {
@@ -1459,8 +1459,8 @@
             "title": "Shaking Table Tests of the Cable Tray System in Nuclear Power Plants",
             "type": "article-journal"
         },
-        "id": "BAO-2017-SHA",
         "pdf_saved": true,
+        "reference_id": "BAO-2017-SHA",
         "study_type": "Experiment"
     },
     {
@@ -1501,8 +1501,8 @@
             "title": "Evaluation of MCC seismic response according to the frequency contents through the shake table test",
             "type": "article-journal"
         },
-        "id": "SUN-2021-EVA",
         "pdf_saved": true,
+        "reference_id": "SUN-2021-EVA",
         "study_type": "Experiment"
     },
     {
@@ -1535,8 +1535,8 @@
             "title": "Experimental Evaluations on Seismic Performances of Porcelain and GFRP Composite UHV GIS Bushings",
             "type": "article-journal"
         },
-        "id": "CHA-2022-EXP",
         "pdf_saved": true,
+        "reference_id": "CHA-2022-EXP",
         "study_type": "Experiment"
     },
     {
@@ -1596,8 +1596,8 @@
             "title": "Earthquake and fire performance of a mid-rise cold-formed steel framed building \u2013 test program and test results: Final Report",
             "type": "report"
         },
-        "id": "WAN-2018-EAR",
         "pdf_saved": true,
+        "reference_id": "WAN-2018-EAR",
         "study_type": "Experiment"
     },
     {
@@ -1695,8 +1695,8 @@
             "title": "Full-scale structural and nonstructural building system performance during earthquakes and post-earthquake fire \u2013 test results",
             "type": "report"
         },
-        "id": "PAN-2013-FUL",
         "pdf_saved": true,
+        "reference_id": "PAN-2013-FUL",
         "study_type": "Experiment"
     },
     {
@@ -1773,8 +1773,8 @@
             "title": "Full-Scale Structural and Nonstructural Building System Performance during Earthquakes: Part II \u2013 NCS Damage States",
             "type": "article-journal"
         },
-        "id": "PAN-2016-FUL",
         "pdf_saved": true,
+        "reference_id": "PAN-2016-FUL",
         "study_type": "Experiment"
     },
     {
@@ -1819,8 +1819,8 @@
             "title": "Seismic performance of novel low-damage stair system: Precast reinforced concrete stair isolated with a sliding joint",
             "type": "article-journal"
         },
-        "id": "ZHA-2024-SEI",
         "pdf_saved": true,
+        "reference_id": "ZHA-2024-SEI",
         "study_type": "Experiment"
     },
     {
@@ -1865,8 +1865,8 @@
             "title": "Seismic behavior of prefabricated reinforced concrete stair isolated by high damping rubber bearings",
             "type": "article-journal"
         },
-        "id": "ZHA-2023-SEI",
         "pdf_saved": true,
+        "reference_id": "ZHA-2023-SEI",
         "study_type": "Experiment"
     },
     {
@@ -1903,8 +1903,8 @@
             "title": "Seismic behavior of reinforced concrete frame staircase with separated slab stairs",
             "type": "article-journal"
         },
-        "id": "CON-2021-SEI",
         "pdf_saved": true,
+        "reference_id": "CON-2021-SEI",
         "study_type": "Experiment"
     },
     {
@@ -1976,8 +1976,8 @@
             "title": "Performance of a 10-story steel stair tower within the NHERI TallWood Building",
             "type": "paper-conference"
         },
-        "id": "SOR-2024-PER",
         "pdf_saved": true,
+        "reference_id": "SOR-2024-PER",
         "study_type": "Experiment"
     },
     {
@@ -2010,8 +2010,8 @@
             "title": "Experimental investigations into the fragility of commercial glazing systems in New Zealand",
             "type": "paper-conference"
         },
-        "id": "ARI-2020-EXP",
         "pdf_saved": true,
+        "reference_id": "ARI-2020-EXP",
         "study_type": "Experiment"
     },
     {
@@ -2036,8 +2036,8 @@
             "title": "Experimental Seismic Study of Pressurized Fire Sprinkler Piping Subsystems",
             "type": "thesis"
         },
-        "id": "TIA-2012-EXP",
         "pdf_saved": true,
+        "reference_id": "TIA-2012-EXP",
         "study_type": "Experiment"
     },
     {
@@ -2081,8 +2081,8 @@
             "title": "Seismic response of pressurized full-scale fire sprinkler piping system in six-story building",
             "type": "article-journal"
         },
-        "id": "JIT-2024-SEI",
         "pdf_saved": true,
+        "reference_id": "JIT-2024-SEI",
         "study_type": "Experiment"
     },
     {
@@ -2117,8 +2117,8 @@
             "title": "Experimental evaluation of the seismic performance of hospital piping subassemblies",
             "type": "report"
         },
-        "id": "GOO-2007-EXP",
         "pdf_saved": true,
+        "reference_id": "GOO-2007-EXP",
         "study_type": "Experiment"
     },
     {
@@ -2166,8 +2166,8 @@
             "type": "article-journal",
             "volume": "9"
         },
-        "id": "MEM-2003-SEI",
         "pdf_saved": true,
+        "reference_id": "MEM-2003-SEI",
         "study_type": "Experiment"
     },
     {
@@ -2206,8 +2206,8 @@
             "title": "Architectural Glass Seismic Behavior Fragility Curve Development",
             "type": "report"
         },
-        "id": "MEM-2011-ARC",
         "pdf_saved": true,
+        "reference_id": "MEM-2011-ARC",
         "study_type": "Experiment"
     },
     {
@@ -2257,8 +2257,8 @@
             "title": "Seismic performance of two-side structural silicone glazing systems",
             "type": "chapter"
         },
-        "id": "MEM-2006-SEI",
         "pdf_saved": true,
+        "reference_id": "MEM-2006-SEI",
         "study_type": "Experiment"
     },
     {
@@ -2306,8 +2306,8 @@
             "type": "article-journal",
             "volume": "22"
         },
-        "id": "MEM-2006-ARC",
         "pdf_saved": true,
+        "reference_id": "MEM-2006-ARC",
         "study_type": "Experiment"
     },
     {
@@ -2332,8 +2332,8 @@
             "title": "Development of a closed-form equation and fragility curves for performance-based seismic design ofglass curtain wall and storefront systems",
             "type": "thesis"
         },
-        "id": "OBR-2009-DEV",
         "pdf_saved": true,
+        "reference_id": "OBR-2009-DEV",
         "study_type": "Experiment"
     },
     {
@@ -2356,8 +2356,8 @@
             "title": "FEMA P-58: Seismic Performance Assessment of Buildings",
             "type": "report"
         },
-        "id": "FEM-2018-SEI",
         "pdf_saved": false,
+        "reference_id": "FEM-2018-SEI",
         "study_type": "Other"
     },
     {
@@ -2380,8 +2380,8 @@
             "title": "Seismic Fragility of Standard Building Stairs",
             "type": "report"
         },
-        "id": "HIG-2011-SEI",
         "pdf_saved": true,
+        "reference_id": "HIG-2011-SEI",
         "study_type": "Experiment"
     },
     {
@@ -2420,8 +2420,8 @@
             "title": "Seismic Fragility of Suspended Ceiling Systems",
             "type": "report"
         },
-        "id": "BAD-2006-SEI",
         "pdf_saved": true,
+        "reference_id": "BAD-2006-SEI",
         "study_type": "Experiment"
     },
     {
@@ -2444,8 +2444,8 @@
             "title": "Interior Cold-Formed Steel Framed Gypsum Partition Walls",
             "type": "report"
         },
-        "id": "MOS-2016-INT",
         "pdf_saved": true,
+        "reference_id": "MOS-2016-INT",
         "study_type": "Experiment"
     }
 ]

--- a/resources/example_data/reference.json
+++ b/resources/example_data/reference.json
@@ -1,7 +1,7 @@
 [
   {
     "_comment": "This is an example for a Reference object. The csl_data field contains Citation Style Language (CSL) JSON format citation metadata.",
-    "id": "SMITH-2020-EXP",
+    "reference_id": "SMITH-2020-EXP",
     "study_type": "Experiment",
     "comp_type": "Example Component Type Description",
     "pdf_saved": "True",


### PR DESCRIPTION
## Summary
- Replace `Reference.id` (CharField primary key) with `reference_id` (CharField, unique) and auto-generated BigAutoField PK, mirroring the Component pattern
- Add `to_field='reference_id'` on Experiment and FragilityCurve foreign keys
- Use 3-step migration strategy: add fields (0018), populate + verify (0019), swap PK (0020)
- Update serializer, ingest, export, admin, tests, example data, and canonical JSON files
- Fix pre-existing fixture load conflict by excluding contenttypes and auth.permission from dumpdata -> add to README.md

## Test plan
- [x] All 84 unit tests pass (`python manage.py test ned_app.tests`)
- [x] Both round-trip integrity tests pass (`test_db_round_trip`, `test_json_to_db_to_json_round_trip_is_lossless`)
- [x] `reference.json` uses `reference_id` key (63 entries, no top-level `id`)
- [x] Experiment and FragilityCurve FK values unchanged (same string references)